### PR TITLE
Note editor Mobile view doesn't play for long enough

### DIFF
--- a/core/audio_context_manager.js
+++ b/core/audio_context_manager.js
@@ -38,11 +38,15 @@ var pxtblocky;
             return undefined;
         }
         function mute(mute) {
+            if (!_context)
+                return;
             _mute = mute;
             stop();
         }
         AudioContextManager.mute = mute;
         function stop() {
+            if (!_context)
+                return;
             _vco.disconnect();
             _frequency = 0;
         }

--- a/core/field_note.js
+++ b/core/field_note.js
@@ -384,29 +384,13 @@ var pxtblocky;
                     currentSelectedKey = key;
                 }
                 //  Listener when a new key is selected
-                goog.events.listen(key.getElement(), goog.events.EventType.MOUSEDOWN, function () {
-                    var cnt = ++soundingKeys;
-                    var freq = this.getContent().getAttribute("tag");
-                    var script;
-                    if (currentSelectedKey != null) {
-                        script = currentSelectedKey.getContent();
-                        script.style.backgroundColor = previousColor;
-                    }
-                    script = this.getContent();
-                    if (currentSelectedKey !== this) {
-                        previousColor = script.style.backgroundColor;
-                        thisField.setValue(thisField.callValidator(freq));
-                        thisField.setText(thisField.callValidator(freq));
-                    }
-                    currentSelectedKey = this;
-                    script.style.backgroundColor = selectedKeyColor;
-                    Blockly.FieldTextInput.htmlInput_.value = thisField.getText();
-                    pxtblocky.AudioContextManager.tone(freq);
-                    pxtblocky.FieldNote.superClass_.dispose.call(this);
-                }, false, key);
-                goog.events.listen(key.getElement(), goog.events.EventType.MOUSEUP, function () {
-                    pxtblocky.AudioContextManager.stop();
-                }, false, key);
+                if (!mobile) {
+                    goog.events.listen(key.getElement(), goog.events.EventType.MOUSEDOWN, soundKey, false, key);
+                }
+                else {
+                    //  Listener when a new key is selected in MOBILE
+                    goog.events.listen(key.getElement(), goog.events.EventType.TOUCHSTART, soundKey, false, key);
+                }
                 //  Listener when the mouse is over a key
                 goog.events.listen(key.getElement(), goog.events.EventType.MOUSEOVER, function () {
                     var script = showNoteLabel.getContent();
@@ -419,6 +403,18 @@ var pxtblocky;
                 // set octaves different from first octave invisible
                 if (pagination && i > 11)
                     key.setVisible(false);
+            }
+            // event listener to stop sound
+            if (!mobile) {
+                document.addEventListener(goog.events.EventType.MOUSEUP, function () {
+                    pxtblocky.AudioContextManager.stop();
+                });
+            }
+            else {
+                // event listener to stop sound on MOBILE
+                document.addEventListener(goog.events.EventType.TOUCHEND, function () {
+                    pxtblocky.AudioContextManager.stop();
+                }, false);
             }
             //  render note label
             var showNoteLabel = new goog.ui.ColorButton();
@@ -485,6 +481,29 @@ var pxtblocky;
                     scriptLabel.innerText = "Octave #" + (currentPage_1 + 1);
                     this.labelHeight_ = document.getElementsByClassName("blocklyNoteLabel")[0].offsetHeight;
                 }, false, nextButton);
+            }
+            /** create the key sound
+             *
+             */
+            function soundKey() {
+                var cnt = ++soundingKeys;
+                var freq = this.getContent().getAttribute("tag");
+                var script;
+                if (currentSelectedKey != null) {
+                    script = currentSelectedKey.getContent();
+                    script.style.backgroundColor = previousColor;
+                }
+                script = this.getContent();
+                if (currentSelectedKey !== this) {
+                    previousColor = script.style.backgroundColor;
+                    thisField.setValue(thisField.callValidator(freq));
+                    thisField.setText(thisField.callValidator(freq));
+                }
+                currentSelectedKey = this;
+                script.style.backgroundColor = selectedKeyColor;
+                Blockly.FieldTextInput.htmlInput_.value = thisField.getText();
+                pxtblocky.AudioContextManager.tone(freq);
+                pxtblocky.FieldNote.superClass_.dispose.call(this);
             }
             /** get width of blockly editor space
              * @return {number} width of the blockly editor workspace

--- a/core/field_note.js
+++ b/core/field_note.js
@@ -407,21 +407,6 @@ var pxtblocky;
                 if (pagination && i > 11)
                     key.setVisible(false);
             }
-            // event listener to stop sound
-            if (!mobile) {
-                document.addEventListener(goog.events.EventType.MOUSEUP, function () {
-                    pxtblocky.AudioContextManager.stop();
-                });
-            }
-            else {
-                /** event listener to stop sound on MOBILE when the touch end
-                 *   It is necessary to use TOUCHEND event to allow passive event listeners
-                 *   to avoid preventDefault() call that blocks listener
-                 */
-                document.addEventListener(goog.events.EventType.TOUCHEND, function () {
-                    pxtblocky.AudioContextManager.stop();
-                }, false);
-            }
             //  render note label
             var showNoteLabel = new goog.ui.ColorButton();
             var showNoteStyle = getShowNoteStyle(topPosition, leftPosition, mobile);
@@ -507,6 +492,11 @@ var pxtblocky;
                 script.style.backgroundColor = selectedKeyColor;
                 Blockly.FieldTextInput.htmlInput_.value = thisField.getText();
                 pxtblocky.AudioContextManager.tone(freq);
+                setTimeout(function () {
+                    // compare current sound counter with listener sound counter (avoid async problems)
+                    if (soundingKeys == cnt)
+                        pxtblocky.AudioContextManager.stop();
+                }, 300);
                 pxtblocky.FieldNote.superClass_.dispose.call(this);
             }
             /** get width of blockly editor space

--- a/core/field_note.js
+++ b/core/field_note.js
@@ -388,7 +388,10 @@ var pxtblocky;
                     goog.events.listen(key.getElement(), goog.events.EventType.MOUSEDOWN, soundKey, false, key);
                 }
                 else {
-                    //  Listener when a new key is selected in MOBILE
+                    /**  Listener when a new key is selected in MOBILE
+                     *   It is necessary to use TOUCHSTART event to allow passive event listeners
+                     *   to avoid preventDefault() call that blocks listener
+                     */
                     goog.events.listen(key.getElement(), goog.events.EventType.TOUCHSTART, soundKey, false, key);
                 }
                 //  Listener when the mouse is over a key
@@ -411,7 +414,10 @@ var pxtblocky;
                 });
             }
             else {
-                // event listener to stop sound on MOBILE
+                /** event listener to stop sound on MOBILE when the touch end
+                 *   It is necessary to use TOUCHEND event to allow passive event listeners
+                 *   to avoid preventDefault() call that blocks listener
+                 */
                 document.addEventListener(goog.events.EventType.TOUCHEND, function () {
                     pxtblocky.AudioContextManager.stop();
                 }, false);
@@ -482,9 +488,7 @@ var pxtblocky;
                     this.labelHeight_ = document.getElementsByClassName("blocklyNoteLabel")[0].offsetHeight;
                 }, false, nextButton);
             }
-            /** create the key sound
-             *
-             */
+            // create the key sound
             function soundKey() {
                 var cnt = ++soundingKeys;
                 var freq = this.getContent().getAttribute("tag");

--- a/ts/core/audio_context_manager.ts
+++ b/ts/core/audio_context_manager.ts
@@ -42,11 +42,15 @@ namespace pxtblocky {
         }
 
         export function mute(mute: boolean) {
+            if (!_context)
+                return;
             _mute = mute;
             stop();
         }
 
         export function stop() {
+            if (!_context)
+                return;
             _vco.disconnect();
             _frequency = 0;
         }

--- a/ts/core/field_note.ts
+++ b/ts/core/field_note.ts
@@ -421,7 +421,10 @@ namespace pxtblocky {
                         , false, key
                     );
                 } else {
-                    //  Listener when a new key is selected in MOBILE
+                    /**  Listener when a new key is selected in MOBILE
+                     *   It is necessary to use TOUCHSTART event to allow passive event listeners
+                     *   to avoid preventDefault() call that blocks listener
+                     */
                     goog.events.listen(key.getElement(),
                         goog.events.EventType.TOUCHSTART, soundKey
                         , false, key
@@ -451,7 +454,10 @@ namespace pxtblocky {
                     AudioContextManager.stop();
                 });
             } else {
-                // event listener to stop sound on MOBILE
+                /** event listener to stop sound on MOBILE when the touch end
+                 *   It is necessary to use TOUCHEND event to allow passive event listeners
+                 *   to avoid preventDefault() call that blocks listener
+                 */
                 document.addEventListener(goog.events.EventType.TOUCHEND, function () {
                     AudioContextManager.stop();
                 }, false);
@@ -531,9 +537,7 @@ namespace pxtblocky {
                     }, false, nextButton
                 );
             }
-            /** create the key sound
-             * 
-             */
+            // create the key sound
             function soundKey() {
                 let cnt = ++soundingKeys;
                 let freq = this.getContent().getAttribute("tag");

--- a/ts/core/field_note.ts
+++ b/ts/core/field_note.ts
@@ -415,36 +415,18 @@ namespace pxtblocky {
                 }
 
                 //  Listener when a new key is selected
-                goog.events.listen(key.getElement(),
-                    goog.events.EventType.MOUSEDOWN,
-                    function () {
-                        let cnt = ++soundingKeys;
-                        let freq = this.getContent().getAttribute("tag");
-                        let script: HTMLElement;
-                        if (currentSelectedKey != null) {
-                            script = currentSelectedKey.getContent() as HTMLElement;
-                            script.style.backgroundColor = previousColor;
-                        }
-                        script = this.getContent() as HTMLElement;
-                        if (currentSelectedKey !== this) { // save color and change values only if is clicking different key
-                            previousColor = script.style.backgroundColor;
-                            thisField.setValue(thisField.callValidator(freq));
-                            thisField.setText(thisField.callValidator(freq));
-                        }
-                        currentSelectedKey = this;
-                        script.style.backgroundColor = selectedKeyColor;
-                        Blockly.FieldTextInput.htmlInput_.value = thisField.getText();
-                        AudioContextManager.tone(freq);
-                        pxtblocky.FieldNote.superClass_.dispose.call(this);
-                    }, false, key
-                );
-
-                goog.events.listen(key.getElement(),
-                    goog.events.EventType.MOUSEUP,
-                    () => {
-                        AudioContextManager.stop();
-                }, false, key);
-
+                if (!mobile) {
+                    goog.events.listen(key.getElement(),
+                        goog.events.EventType.MOUSEDOWN, soundKey
+                        , false, key
+                    );
+                } else {
+                    //  Listener when a new key is selected in MOBILE
+                    goog.events.listen(key.getElement(),
+                        goog.events.EventType.TOUCHSTART, soundKey
+                        , false, key
+                    );
+                }
                 //  Listener when the mouse is over a key
                 goog.events.listen(key.getElement(),
                     goog.events.EventType.MOUSEOVER,
@@ -461,6 +443,18 @@ namespace pxtblocky {
                 // set octaves different from first octave invisible
                 if (pagination && i > 11)
                     key.setVisible(false);
+            }
+
+            // event listener to stop sound
+            if (!mobile) {
+                document.addEventListener(goog.events.EventType.MOUSEUP, function () {
+                    AudioContextManager.stop();
+                });
+            } else {
+                // event listener to stop sound on MOBILE
+                document.addEventListener(goog.events.EventType.TOUCHEND, function () {
+                    AudioContextManager.stop();
+                }, false);
             }
 
             //  render note label
@@ -537,7 +531,29 @@ namespace pxtblocky {
                     }, false, nextButton
                 );
             }
-
+            /** create the key sound
+             * 
+             */
+            function soundKey() {
+                let cnt = ++soundingKeys;
+                let freq = this.getContent().getAttribute("tag");
+                let script: HTMLElement;
+                if (currentSelectedKey != null) {
+                    script = currentSelectedKey.getContent() as HTMLElement;
+                    script.style.backgroundColor = previousColor;
+                }
+                script = this.getContent() as HTMLElement;
+                if (currentSelectedKey !== this) { // save color and change values only if is clicking different key
+                    previousColor = script.style.backgroundColor;
+                    thisField.setValue(thisField.callValidator(freq));
+                    thisField.setText(thisField.callValidator(freq));
+                }
+                currentSelectedKey = this;
+                script.style.backgroundColor = selectedKeyColor;
+                Blockly.FieldTextInput.htmlInput_.value = thisField.getText();
+                AudioContextManager.tone(freq);
+                pxtblocky.FieldNote.superClass_.dispose.call(this);
+            }
             /** get width of blockly editor space
              * @return {number} width of the blockly editor workspace
              * @private

--- a/ts/core/field_note.ts
+++ b/ts/core/field_note.ts
@@ -447,22 +447,6 @@ namespace pxtblocky {
                 if (pagination && i > 11)
                     key.setVisible(false);
             }
-
-            // event listener to stop sound
-            if (!mobile) {
-                document.addEventListener(goog.events.EventType.MOUSEUP, function () {
-                    AudioContextManager.stop();
-                });
-            } else {
-                /** event listener to stop sound on MOBILE when the touch end
-                 *   It is necessary to use TOUCHEND event to allow passive event listeners
-                 *   to avoid preventDefault() call that blocks listener
-                 */
-                document.addEventListener(goog.events.EventType.TOUCHEND, function () {
-                    AudioContextManager.stop();
-                }, false);
-            }
-
             //  render note label
             let showNoteLabel = new goog.ui.ColorButton();
             let showNoteStyle = getShowNoteStyle(topPosition, leftPosition, mobile);
@@ -556,6 +540,11 @@ namespace pxtblocky {
                 script.style.backgroundColor = selectedKeyColor;
                 Blockly.FieldTextInput.htmlInput_.value = thisField.getText();
                 AudioContextManager.tone(freq);
+                setTimeout(function () {
+                    // compare current sound counter with listener sound counter (avoid async problems)
+                    if (soundingKeys == cnt)
+                        AudioContextManager.stop();
+                }, 300);
                 pxtblocky.FieldNote.superClass_.dispose.call(this);
             }
             /** get width of blockly editor space


### PR DESCRIPTION
fixes #16 

The problem was that mouse events call preventDefault() and browser needs to wait for the events to finish. That's why now I use touch events to avoid that call and guarantee browser that the listener will not call preventDefault()

more information: 
www.chromestatus.com/features/5093566007214080
developers.google.com/web/updates/2017/01/scrolling-intervention