### PR TITLE
Prevent FieldNumber from returning the empty string

### DIFF
--- a/core/field_number.js
+++ b/core/field_number.js
@@ -358,3 +358,15 @@ Blockly.FieldNumber.prototype.classValidator = function(text) {
   }
   return String(n);
 };
+
+/**
+ * pxtblockly: redefined this function to simulate the
+ * old blockly behavior of calling the class validator when text
+ * is edited rather than when focus is lost. Otherwise this might
+ * return garbage values if called while text is being edited.
+ * @return {string} Current value.
+ */
+Blockly.FieldNumber.prototype.getValue = function() {
+  var value = Blockly.FieldNumber.superClass_.getValue.call(this);
+  return this.classValidator(value);
+};


### PR DESCRIPTION
Note that this is for the develop branch. We have an issue where if you call `getValue()` while the text of a number input is being edited, you can end up getting whatever is currently in the entry field instead of a valid number. Old Blockly didn't have this issue because it called the number validator more frequently. 