### PR TITLE
Edge and IE fixes

### DIFF
--- a/core/css.js
+++ b/core/css.js
@@ -432,10 +432,11 @@ Blockly.Css.CONTENT = [
   '}',
 
   '.blocklyText {',
+    'cursor: default;',
     'fill: #fff;',
-    'font-family: "Helvetica Neue", Helvetica, sans-serif;',
+    'font-family: "Helvetica Neue", "Segoe UI", Helvetica, sans-serif;',
     'font-size: 12pt;',
-    'font-weight: 500;',
+    'font-weight: bold;',
   '}',
 
   '.blocklyTextTruncated {',
@@ -554,7 +555,7 @@ Blockly.Css.CONTENT = [
 
   '.blocklyHtmlInput {',
     'border: none;',
-    'font-family: "Helvetica Neue", Helvetica, sans-serif;',
+    'font-family: "Helvetica Neue", "Segoe UI", Helvetica, sans-serif;',
     'font-size: 12pt;',
     'height: 100%;',
     'margin: 0;',

--- a/core/css.js
+++ b/core/css.js
@@ -204,7 +204,7 @@ Blockly.Css.CONTENT = [
     'box-shadow: 4px 4px 20px 1px rgba(0,0,0,.15);',
     'color: #000;',
     'display: none;',
-    'font-family: "Helvetica Neue", Helvetica, sans-serif;',
+    'font-family: "Helvetica Neue", "Segoe UI", Helvetica, sans-serif;',
     'font-size: 9pt;',
     'opacity: 0.9;',
     'padding: 2px;',
@@ -288,7 +288,7 @@ Blockly.Css.CONTENT = [
     'border: 1px solid $colour_numPadBorder;',
     'cursor: pointer;',
     'font-weight: 600;',
-    'font-family: "Helvetica Neue", Helvetica, sans-serif;',
+    'font-family: "Helvetica Neue", "Segoe UI", Helvetica, sans-serif;',
     'font-size: 12pt;',
     '-webkit-tap-highlight-color: rgba(0,0,0,0);',
   '}',
@@ -325,7 +325,7 @@ Blockly.Css.CONTENT = [
     'overflow: auto;',
     'word-wrap: break-word;',
     'text-align: center;',
-    'font-family: "Helvetica Neue", Helvetica, sans-serif;',
+    'font-family: "Helvetica Neue", "Segoe UI", Helvetica, sans-serif;',
     'font-size: .8em;',
   '}',
 
@@ -681,7 +681,7 @@ Blockly.Css.CONTENT = [
     'overflow-x: visible;',
     'overflow-y: auto;',
     'position: absolute;',
-    'font-family: "Helvetica Neue", Helvetica, sans-serif;',
+    'font-family: "Helvetica Neue", "Segoe UI", Helvetica, sans-serif;',
     'z-index: 40;', /* so blocks go over toolbox when dragging */
   '}',
 
@@ -770,7 +770,7 @@ Blockly.Css.CONTENT = [
 
   '.blocklyTreeLabel {',
     'cursor: default;',
-    'font-family: "Helvetica Neue", Helvetica, sans-serif;',
+    'font-family: "Helvetica Neue", "Segoe UI", Helvetica, sans-serif;',
     'font-size: 16px;',
     'padding: 0 3px;',
     'vertical-align: middle;',
@@ -1101,7 +1101,7 @@ Blockly.Css.CONTENT = [
      'box-shadow: 0 0 0 2px rgba(0, 0, 0, 0.2);',
   '}',
   '.blocklyFieldSliderLabel {',
-    'font-family: "Helvetica Neue", Helvetica, sans-serif;',
+    'font-family: "Helvetica Neue", "Segoe UI", Helvetica, sans-serif;',
     'font-size: 0.65rem;',
     'color: $colour_toolboxText;',
     'margin: 8px;',

--- a/core/field.js
+++ b/core/field.js
@@ -441,16 +441,18 @@ Blockly.Field.getCachedWidth = function(textElement) {
 
   // Attempt to compute fetch the width of the SVG text element.
   try {
-    width = textElement.getComputedTextLength();
+    if (goog.userAgent.IE || goog.userAgent.EDGE) {
+      width = textElement.getBBox().width;
+    } else {
+      width = textElement.getComputedTextLength();
+    }
   } catch (e) {
-    // MSIE 11 and Edge are known to throw "Unexpected call to method or
-    // property access." if the block is hidden. Instead, use an
+    // In other cases where we fail to get the computed text. Instead, use an
     // approximation and do not cache the result. At some later point in time
     // when the block is inserted into the visible DOM, this method will be
     // called again and, at that point in time, will not throw an exception.
-    return textElement.textContent.length * 8;
+    return textElement.textContent.length * 8;    
   }
-
   // Cache the computed width and return.
   if (Blockly.Field.cacheWidths_) {
     Blockly.Field.cacheWidths_[key] = width;

--- a/core/field.js
+++ b/core/field.js
@@ -168,9 +168,8 @@ Blockly.Field.prototype.init = function() {
   this.textElement_ = Blockly.utils.createSvgElement('text',
       {'class': 'blocklyText',
        'x': fieldX,
-       'y': size.height / 2 + Blockly.BlockSvg.FIELD_TOP_PADDING,
-       'dominant-baseline': 'middle',
-       'text-anchor': 'middle'},
+       'dy': '0.6ex',
+       'y': size.height / 2},
       this.fieldGroup_);
 
   this.updateEditable();
@@ -382,7 +381,9 @@ Blockly.Field.prototype.render_ = function() {
     }
 
     // Apply new text element x position.
-    this.textElement_.setAttribute('x', centerTextX);
+    var width = Blockly.Field.getCachedWidth(this.textElement_);
+    var newX = centerTextX - width / 2;
+    this.textElement_.setAttribute('x', newX);
   }
 
   // Update any drawn box to the correct width and height.

--- a/core/field_label.js
+++ b/core/field_label.js
@@ -62,9 +62,7 @@ Blockly.FieldLabel.prototype.init = function() {
   // Build the DOM.
   this.textElement_ = Blockly.utils.createSvgElement('text',
       {'class': 'blocklyText',
-      'y': Blockly.BlockSvg.FIELD_TOP_PADDING,
-      'text-anchor': 'middle',
-      'dominant-baseline': 'middle'
+      'dy': '0.6ex'
     }, null);
   if (this.class_) {
     Blockly.utils.addClass(this.textElement_, this.class_);


### PR DESCRIPTION
- Perf: Edge and IE improvements to not re-render, similar to https://github.com/google/blockly/pull/1326
- Font: Using Segue font which is installed on Windows by default
- Font weight: Using font weight = bold. so it applies the same to both Segoe and Helvetica
- Avoiding text-anchor and dominant-baseline as they are not supported on pre Edge 14. Instead calculating x position explicitly, and using dy for the vertical alignment. 