### PR TITLE
Don't allow empty procedure names

### DIFF
--- a/core/procedures.js
+++ b/core/procedures.js
@@ -157,6 +157,8 @@ Blockly.Procedures.rename = function(name) {
       }
     }
   }
+  //pxtblockly: ensure no empty procedure name is set
+  if (!legalName) return oldName;
   return legalName;
 };
 


### PR DESCRIPTION
If a user edits a procedure name to be blank, we replace it with the original name of the procedure. 

Fixes #72

