### PR TITLE
Better highlighting

### DIFF
--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -283,10 +283,14 @@ Blockly.BlockSvg.prototype.setHighlightBlock = function(isHighlightingBlock) {
   this.isHighlightingBlock_ = isHighlightingBlock;
   // Update the applied SVG filter if the property has changed
   var svg = this.svgPath_;
-  if (this.isHighlightingBlock_ && !svg.hasAttribute('filter')) {
-    svg.setAttribute('filter', 'url(#blocklyStackGlowFilter)');
-  } else if (!this.isHighlightingBlock_ && svg.hasAttribute('filter')) {
-    svg.removeAttribute('filter');
+  if (this.isHighlightingBlock_ && !this.svgPathHighlight_) {
+    this.svgPathHighlight_ = this.svgPath_.cloneNode(true);
+    this.svgPathHighlight_.setAttribute('fill', 'transparent');
+    this.svgPathHighlight_.setAttribute('filter', 'url(#blocklyHighlightGlowFilter)');
+    this.getSvgRoot().appendChild(this.svgPathHighlight_);
+  } else if (!this.isHighlightingBlock_ && this.svgPathHighlight_) {
+    this.getSvgRoot().removeChild(this.svgPathHighlight_);
+    this.svgPathHighlight_ = null;
   }
 };
 

--- a/core/constants.js
+++ b/core/constants.js
@@ -259,6 +259,13 @@ Blockly.STACK_GLOW_RADIUS = 1.3;
 Blockly.REPLACEMENT_GLOW_RADIUS = 2;
 
 /**
+ * Radius of highlight glow, in px.
+ * @type {number}
+ * @const
+ */
+Blockly.HIGHLIGHT_GLOW_RADIUS = .7;
+
+/**
  * ENUM representing that an event is not in any delete areas.
  * Null for backwards compatibility reasons.
  * @const

--- a/core/inject.js
+++ b/core/inject.js
@@ -166,6 +166,27 @@ Blockly.createDom_ = function(container, options) {
        'operator': 'in', 'result': 'outGlow'}, replacementGlowFilter);
   Blockly.utils.createSvgElement('feComposite',
       {'in': 'SourceGraphic', 'in2': 'outGlow', 'operator': 'over'}, replacementGlowFilter);
+
+
+  // Using a dilate distorts the block shape.
+  // Instead use a gaussian blur, and then set all alpha to 1 with a transfer.
+  var highlightGlowFilter = Blockly.utils.createSvgElement('filter',
+    {'id': 'blocklyHighlightGlowFilter',
+      'height': '160%', 'width': '180%', y: '-30%', x: '-40%'}, defs);
+  options.stackGlowBlur = Blockly.utils.createSvgElement('feGaussianBlur',
+    {'in': 'SourceGraphic',
+    'stdDeviation': Blockly.HIGHLIGHT_GLOW_RADIUS}, highlightGlowFilter);
+  // Set all gaussian blur pixels to 1 opacity before applying flood
+  var componentTransfer = Blockly.utils.createSvgElement('feComponentTransfer', {'result': 'outBlur'}, highlightGlowFilter);
+  Blockly.utils.createSvgElement('feFuncA',
+    {'type': 'table', 'tableValues': '0' + goog.string.repeat(' 1', 16)}, componentTransfer);
+  // Color the highlight
+  Blockly.utils.createSvgElement('feFlood',
+    {'flood-color': Blockly.Colours.stackGlow,
+    'flood-opacity': Blockly.Colours.stackGlowOpacity, 'result': 'outColor'}, highlightGlowFilter);
+  Blockly.utils.createSvgElement('feComposite',
+    {'in': 'outColor', 'in2': 'outBlur',
+    'operator': 'in', 'result': 'outGlow'}, highlightGlowFilter);
   /*
     <filter id="blocklyEmbossFilter837493">
       <feGaussianBlur in="SourceAlpha" stdDeviation="1" result="blur" />


### PR DESCRIPTION
Better highlight solved by copying the SVG path of a block above the entire stack, with a transparent background, and applying a filter.

![betterhighlight](https://user-images.githubusercontent.com/16690124/31872102-efdaf3ec-b76d-11e7-940a-ab55750470af.gif)
