### PR TITLE
Fix IE rendering issue causing scrollbar and drag issues

### DIFF
--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -153,7 +153,8 @@ Blockly.BlockSvg.prototype.initSvg = function() {
     for (var i = 0, input; input = this.inputList[i]; i++) {
       input.init();
       if (input.type === Blockly.INPUT_VALUE) {
-        this.initInputShape(input);
+        this.
+        (input);
       }
     }
     var icons = this.getIcons();
@@ -189,7 +190,8 @@ Blockly.BlockSvg.prototype.initInputShape = function(input) {
     'path',
     {
       'class': 'blocklyPath',
-      'style': 'visibility: hidden' // Hide by default - shown when not connected.
+      'style': 'visibility: hidden', // Hide by default - shown when not connected.
+      'd': '' // IE doesn't like paths without the data definition, set an empty default
     },
     this.svgGroup_
   );


### PR DESCRIPTION
Fix issue in IE where the scrollbar and drag breaks in certain cases where an empty input path exists in the rendered block.
As described in https://github.com/Microsoft/pxt-blockly/issues/84, the cases that this appears in our codebase were the ifelse statement and any block that had a get_variable in it. 

The fix here is to define an empty data attribute for the path on initialisation of the path. According to https://www.w3.org/TR/SVGTiny12/paths.html this means the path won't be rendered by the browser, which is okay in this case since we're setting the visibility to hidden anyway. 

Tested on: 
- [x] Edge 16
- [x] Chrome Mac
- [x] Chrome Windows
- [x] Safari
- [x] Firefox Mac
- [x] Firefox Windows