### PR TITLE
Fix rendering and positioning of hidden inputs

### DIFF
--- a/core/input.js
+++ b/core/input.js
@@ -182,6 +182,13 @@ Blockly.Input.prototype.setVisible = function(visible) {
   }
   this.visible_ = visible;
 
+  // pxtblockly: hidden inputs get filtered out of the block's
+  // render list so the input shapes don't get hidden. Hide them
+  // here instead
+  if (!visible && this.outlinePath) {
+    this.outlinePath.setAttribute('style', 'visibility: hidden');
+  }
+
   var display = visible ? 'block' : 'none';
   for (var y = 0, field; field = this.fieldRow[y]; y++) {
     field.setVisible(visible);

--- a/core/rendered_connection.js
+++ b/core/rendered_connection.js
@@ -168,11 +168,14 @@ Blockly.RenderedConnection.prototype.tighten_ = function() {
     if (!svgRoot) {
       throw 'block is not rendered.';
     }
-    // Workspace coordinates.
-    var xy = Blockly.utils.getRelativeXY(svgRoot);
-    block.getSvgRoot().setAttribute('transform',
-        'translate(' + (xy.x - dx) + ',' + (xy.y - dy) + ')');
-    block.moveConnections_(-dx, -dy);
+    // pxtblockly: only move blocks if they are visible
+    if (block.rendered) {
+      // Workspace coordinates.
+      var xy = Blockly.utils.getRelativeXY(svgRoot);
+      block.getSvgRoot().setAttribute('transform',
+          'translate(' + (xy.x - dx) + ',' + (xy.y - dy) + ')');
+      block.moveConnections_(-dx, -dy);
+    }
   }
 };
 


### PR DESCRIPTION
Fixes two bugs:

1. When a value input with no connected block is hidden, the input shape (the thing that is drawn in place of a block) stays rendered while the rest is hidden.
2. When a value input with a connected block is hidden and the parent block is moved, the connection tightening logic was translating the block's SVG but not moving the block's connections. That ended up causing a feedback loop where a block would move way out of position and render incorrectly once the input was un-hidden.

@rachel-fenichel I don't know if these impact mainline Blockly or not; is there a testing process that Sam usually goes through to determine that?