### PR TITLE
Don't register mouse events if pointer events are supported.

### DIFF
--- a/core/blockly.js
+++ b/core/blockly.js
@@ -129,8 +129,10 @@ Blockly.hueToRgb = function(hue) {
  * @return {!Object} Contains width and height properties.
  */
 Blockly.svgSize = function(svg) {
-  return {width: svg.cachedWidth_,
-          height: svg.cachedHeight_};
+  return {
+    width: svg.cachedWidth_,
+    height: svg.cachedHeight_
+  };
 };
 
 /**
@@ -446,27 +448,30 @@ Blockly.bindEventWithChecks_ = function(node, name, thisObject, func,
   };
 
   var bindData = [];
-  if (!window.PointerEvent || !(name in Blockly.Touch.TOUCH_MAP)) {
-    // pxtblockly: don't register a mouse event if pointer events are supported
+  if (window && window.PointerEvent && (name in Blockly.Touch.TOUCH_MAP)) {
+    for (var i = 0, type; type = Blockly.Touch.TOUCH_MAP[name][i]; i++) {
+      node.addEventListener(type, wrapFunc, false);
+      bindData.push([node, type, wrapFunc]);
+    }
+  } else {
     node.addEventListener(name, wrapFunc, false);
     bindData.push([node, name, wrapFunc]);
-  }
 
-  // Add equivalent touch event.
-  if (name in Blockly.Touch.TOUCH_MAP) {
-    var touchWrapFunc = function(e) {
-      wrapFunc(e);
-      // Calling preventDefault stops the browser from scrolling/zooming the
-      // page.
-      var preventDef = !opt_noPreventDefault;
-      if (handled && preventDef) {
-        e.preventDefault();
+    // Add equivalent touch event.
+    if (name in Blockly.Touch.TOUCH_MAP) {
+      var touchWrapFunc = function(e) {
+        wrapFunc(e);
+        // Calling preventDefault stops the browser from scrolling/zooming the
+        // page.
+        var preventDef = !opt_noPreventDefault;
+        if (handled && preventDef) {
+          e.preventDefault();
+        }
+      };
+      for (var i = 0, type; type = Blockly.Touch.TOUCH_MAP[name][i]; i++) {
+        node.addEventListener(type, touchWrapFunc, false);
+        bindData.push([node, type, touchWrapFunc]);
       }
-    };
-    for (var i = 0, eventName;
-         eventName = Blockly.Touch.TOUCH_MAP[name][i]; i++) {
-      node.addEventListener(eventName, touchWrapFunc, false);
-      bindData.push([node, eventName, touchWrapFunc]);
     }
   }
   return bindData;
@@ -496,31 +501,34 @@ Blockly.bindEvent_ = function(node, name, thisObject, func) {
   };
 
   var bindData = [];
-  if (!window.PointerEvent || !(name in Blockly.Touch.TOUCH_MAP)) {
-    // pxtblockly: don't register a mouse event if pointer events are supported
+  if (window && window.PointerEvent && (name in Blockly.Touch.TOUCH_MAP)) {
+    for (var i = 0, type; type = Blockly.Touch.TOUCH_MAP[name][i]; i++) {
+      node.addEventListener(type, wrapFunc, false);
+      bindData.push([node, type, wrapFunc]);
+    }
+  } else {
     node.addEventListener(name, wrapFunc, false);
     bindData.push([node, name, wrapFunc]);
-  }
 
-  // Add equivalent touch event.
-  if (name in Blockly.Touch.TOUCH_MAP) {
-    var touchWrapFunc = function(e) {
-      // Punt on multitouch events.
-      if (e.changedTouches && e.changedTouches.length == 1) {
-        // Map the touch event's properties to the event.
-        var touchPoint = e.changedTouches[0];
-        e.clientX = touchPoint.clientX;
-        e.clientY = touchPoint.clientY;
+    // Add equivalent touch event.
+    if (name in Blockly.Touch.TOUCH_MAP) {
+      var touchWrapFunc = function(e) {
+        // Punt on multitouch events.
+        if (e.changedTouches && e.changedTouches.length == 1) {
+          // Map the touch event's properties to the event.
+          var touchPoint = e.changedTouches[0];
+          e.clientX = touchPoint.clientX;
+          e.clientY = touchPoint.clientY;
+        }
+        wrapFunc(e);
+
+        // Stop the browser from scrolling/zooming the page.
+        e.preventDefault();
+      };
+      for (var i = 0, type; type = Blockly.Touch.TOUCH_MAP[name][i]; i++) {
+        node.addEventListener(type, touchWrapFunc, false);
+        bindData.push([node, type, touchWrapFunc]);
       }
-      wrapFunc(e);
-
-      // Stop the browser from scrolling/zooming the page.
-      e.preventDefault();
-    };
-    for (var i = 0, eventName;
-         eventName = Blockly.Touch.TOUCH_MAP[name][i]; i++) {
-      node.addEventListener(eventName, touchWrapFunc, false);
-      bindData.push([node, eventName, touchWrapFunc]);
     }
   }
   return bindData;

--- a/core/blockly.js
+++ b/core/blockly.js
@@ -445,11 +445,12 @@ Blockly.bindEventWithChecks_ = function(node, name, thisObject, func,
     }
   };
 
-  if (!window.PointerEvent) {
+  var bindData = [];
+  if (!window.PointerEvent || !(name in Blockly.Touch.TOUCH_MAP)) {
     // pxtblockly: don't register a mouse event if pointer events are supported
     node.addEventListener(name, wrapFunc, false);
+    bindData.push([node, name, wrapFunc]);
   }
-  var bindData = [[node, name, wrapFunc]];
 
   // Add equivalent touch event.
   if (name in Blockly.Touch.TOUCH_MAP) {
@@ -494,11 +495,12 @@ Blockly.bindEvent_ = function(node, name, thisObject, func) {
     }
   };
 
-  if (!window.PointerEvent) {
+  var bindData = [];
+  if (!window.PointerEvent || !(name in Blockly.Touch.TOUCH_MAP)) {
     // pxtblockly: don't register a mouse event if pointer events are supported
     node.addEventListener(name, wrapFunc, false);
+    bindData.push([node, name, wrapFunc]);
   }
-  var bindData = [[node, name, wrapFunc]];
 
   // Add equivalent touch event.
   if (name in Blockly.Touch.TOUCH_MAP) {

--- a/core/blockly.js
+++ b/core/blockly.js
@@ -445,7 +445,10 @@ Blockly.bindEventWithChecks_ = function(node, name, thisObject, func,
     }
   };
 
-  node.addEventListener(name, wrapFunc, false);
+  if (!window.PointerEvent) {
+    // pxtblockly: don't register a mouse event if pointer events are supported
+    node.addEventListener(name, wrapFunc, false);
+  }
   var bindData = [[node, name, wrapFunc]];
 
   // Add equivalent touch event.
@@ -491,7 +494,10 @@ Blockly.bindEvent_ = function(node, name, thisObject, func) {
     }
   };
 
-  node.addEventListener(name, wrapFunc, false);
+  if (!window.PointerEvent) {
+    // pxtblockly: don't register a mouse event if pointer events are supported
+    node.addEventListener(name, wrapFunc, false);
+  }
   var bindData = [[node, name, wrapFunc]];
 
   // Add equivalent touch event.

--- a/core/bubble.js
+++ b/core/bubble.js
@@ -357,11 +357,16 @@ Blockly.Bubble.prototype.registerResizeEvent = function(callback) {
 
 /**
  * Move this bubble to the top of the stack.
+ * @return {!boolean} Whether or not the bubble has been moved.
  * @private
  */
 Blockly.Bubble.prototype.promote_ = function() {
   var svgGroup = this.bubbleGroup_.parentNode;
-  svgGroup.appendChild(this.bubbleGroup_);
+  if (svgGroup.lastChild !== this.bubbleGroup_) {
+    svgGroup.appendChild(this.bubbleGroup_);
+    return true;
+  }
+  return false;
 };
 
 /**

--- a/core/comment.js
+++ b/core/comment.js
@@ -114,7 +114,7 @@ Blockly.Comment.prototype.createEditor_ = function() {
   body.appendChild(textarea);
   this.textarea_ = textarea;
   this.foreignObject_.appendChild(body);
-  Blockly.bindEventWithChecks_(textarea, 'mouseup', this, this.textareaFocus_);
+  Blockly.bindEventWithChecks_(textarea, 'mouseup', this, this.textareaFocus_, true, true);
   // Don't zoom with mousewheel.
   Blockly.bindEventWithChecks_(textarea, 'wheel', this, function(e) {
     e.stopPropagation();
@@ -213,10 +213,11 @@ Blockly.Comment.prototype.textareaFocus_ = function(/*e*/) {
   // Ideally this would be hooked to the focus event for the comment.
   // However doing so in Firefox swallows the cursor for unknown reasons.
   // So this is hooked to mouseup instead.  No big deal.
-  this.bubble_.promote_();
-  // Since the act of moving this node within the DOM causes a loss of focus,
-  // we need to reapply the focus.
-  this.textarea_.focus();
+  if (this.bubble_.promote_()) {
+    // Since the act of moving this node within the DOM causes a loss of focus,
+    // we need to reapply the focus.
+    this.textarea_.focus();
+  }
 };
 
 /**

--- a/core/css.js
+++ b/core/css.js
@@ -558,9 +558,12 @@ Blockly.Css.CONTENT = [
   '.blocklyCommentTextarea {',
     'background-color: #ffc;',
     'border: 0;',
+    'outline: 0;',
     'margin: 0;',
     'padding: 2px;',
     'resize: none;',
+    'display: block;',
+    'overflow: none;',
   '}',
 
   '.blocklyHtmlInput {',

--- a/core/field_dropdown.js
+++ b/core/field_dropdown.js
@@ -173,11 +173,14 @@ Blockly.FieldDropdown.prototype.showEditor_ = function() {
 
   var thisField = this;
 
+  var selected = false;
   function callback(e) {
+    if (selected) return;
     var menu = this;
     var menuItem = e.target;
     if (menuItem) {
       thisField.onItemSelected(menu, menuItem);
+      selected = true;
     }
     Blockly.DropDownDiv.hide();
     Blockly.Events.setGroup(false);
@@ -316,6 +319,8 @@ Blockly.FieldDropdown.prototype.getAnchorDimensions_ = function() {
  * @param {!goog.ui.MenuItem} menuItem The MenuItem selected within menu.
  */
 Blockly.FieldDropdown.prototype.onItemSelected = function(menu, menuItem) {
+  // pxtblockly: add extra check to make sure we don't double tap on any option
+  if (!this.dropDownOpen_) return;
   var value = menuItem.getValue();
   if (this.sourceBlock_) {
     // Call any validation function, and allow it to override.

--- a/core/field_number.js
+++ b/core/field_number.js
@@ -160,7 +160,7 @@ Blockly.FieldNumber.prototype.showEditor_ = function() {
   Blockly.FieldNumber.superClass_.showEditor_.call(this, false, showNumPad);
 
   // Show a numeric keypad in the drop-down on touch
-  if (showNumPad) {
+  if (true) {
     this.showNumPad_();
   }
 };
@@ -266,7 +266,7 @@ Blockly.FieldNumber.prototype.addButtons_ = function(contentDiv) {
  * Call for when a num-pad number or punctuation button is touched.
  * Determine what the user is inputting and update the text field appropriately.
  */
-Blockly.FieldNumber.numPadButtonTouch = function() {
+Blockly.FieldNumber.numPadButtonTouch = function(e) {
   // String of the button (e.g., '7')
   var spliceValue = this.innerHTML;
   // Old value of the text field
@@ -279,17 +279,24 @@ Blockly.FieldNumber.numPadButtonTouch = function() {
   var newValue = oldValue.slice(0, selectionStart) + spliceValue +
       oldValue.slice(selectionEnd);
 
+  // pxtblockly: workaround iframe + android issue where it inserts values to the front
+  if (selectionEnd - selectionStart == 0) { // Length of selection == 0
+    newValue = oldValue + spliceValue;
+  }
+
   Blockly.FieldNumber.updateDisplay_(newValue);
 
   // This is just a click.
   Blockly.Touch.clearTouchIdentifier();
+
+  e.preventDefault();
 };
 
 /**
  * Call for when the num-pad erase button is touched.
  * Determine what the user is asking to erase, and erase it.
  */
-Blockly.FieldNumber.numPadEraseButtonTouch = function() {
+Blockly.FieldNumber.numPadEraseButtonTouch = function(e) {
   // Old value of the text field
   var oldValue = Blockly.FieldTextInput.htmlInput_.value;
   // Determine what is selected to erase (if anything)
@@ -300,13 +307,15 @@ Blockly.FieldNumber.numPadEraseButtonTouch = function() {
       oldValue.slice(selectionEnd);
   if (selectionEnd - selectionStart == 0) { // Length of selection == 0
     // Delete the last character if nothing was selected
-    newValue = oldValue.slice(0, selectionStart - 1) +
-        oldValue.slice(selectionStart);
+    newValue = selectionEnd == 0 ? oldValue.slice(0, oldValue.length - 1) :
+      oldValue.slice(0, selectionStart - 1) + oldValue.slice(selectionStart);
   }
   Blockly.FieldNumber.updateDisplay_(newValue);
 
   // This is just a click.
   Blockly.Touch.clearTouchIdentifier();
+
+  e.preventDefault();
 };
 
 /**

--- a/core/gesture.js
+++ b/core/gesture.js
@@ -446,7 +446,7 @@ Blockly.Gesture.prototype.doStart = function(e) {
   }
 
   if (goog.string.caseInsensitiveEquals(e.type, 'touchstart') ||
-      goog.string.caseInsensitiveEquals(e.type, 'pointerdown')) {
+      (goog.string.caseInsensitiveEquals(e.type, 'pointerdown') && e.pointerType != 'mouse')) {
     Blockly.longStart_(e, this);
   }
 

--- a/core/gesture.js
+++ b/core/gesture.js
@@ -464,7 +464,7 @@ Blockly.Gesture.prototype.bindMouseEvents = function(e) {
   this.onMoveWrapper_ = Blockly.bindEventWithChecks_(
     document, 'mousemove', null, this.handleMove.bind(this));
   this.onUpWrapper_ = Blockly.bindEventWithChecks_(
-      document, 'mouseup', null, this.handleUp.bind(this));
+    document, 'mouseup', null, this.handleUp.bind(this));
 
   e.preventDefault();
   e.stopPropagation();

--- a/core/touch.js
+++ b/core/touch.js
@@ -222,7 +222,7 @@ Blockly.Touch.isMouseOrTouchEvent = function(e) {
  */
 Blockly.Touch.isTouchEvent = function(e) {
   return goog.string.startsWith(e.type, 'touch') ||
-      goog.string.startsWith(e.type, 'pointer');
+      (goog.string.startsWith(e.type, 'pointer') && e.pointerType != 'mouse');
 };
 
 /**

--- a/core/touch.js
+++ b/core/touch.js
@@ -47,11 +47,17 @@ Blockly.Touch.touchIdentifier_ = null;
  * @type {Object}
  */
 Blockly.Touch.TOUCH_MAP = {};
-if (window.PointerEvent) {
+if (window && window.PointerEvent) {
   Blockly.Touch.TOUCH_MAP = {
     'mousedown': ['pointerdown'],
+    'mouseenter': ['pointerenter'],
+    'mouseleave': ['pointerleave'],
     'mousemove': ['pointermove'],
-    'mouseup': ['pointerup', 'pointercancel']
+    'mouseout': ['pointerout'],
+    'mouseover': ['pointerover'],
+    'mouseup': ['pointerup', 'pointercancel'],
+    'touchend': ['pointerup'],
+    'touchcancel': ['pointercancel']
   };
 } else if (goog.events.BrowserFeature.TOUCH_ENABLED) {
   Blockly.Touch.TOUCH_MAP = {
@@ -102,7 +108,7 @@ Blockly.longStart_ = function(e, gesture) {
 
 /**
  * Nope, that's not a long-press.  Either touchend or touchcancel was fired,
- * or a drag hath begun.  Kill the queued long-press task.
+ * or a drag has begun.  Kill the queued long-press task.
  * @private
  */
 Blockly.longStop_ = function() {

--- a/core/touch_gesture.js
+++ b/core/touch_gesture.js
@@ -123,6 +123,7 @@ Blockly.TouchGesture.prototype.bindMouseEvents = function(e) {
     document, 'mouseup', null, this.handleUp.bind(this), /*opt_noCaptureIdentifier*/ true);
 
   e.preventDefault();
+  e.stopPropagation();
 };
 
 /**
@@ -131,7 +132,7 @@ Blockly.TouchGesture.prototype.bindMouseEvents = function(e) {
  * @package
  */
 Blockly.TouchGesture.prototype.handleStart = function(e) {
-  if (!this.isDragging) {
+  if (this.isDragging()) {
     // A drag has already started, so this can no longer be a pinch-zoom.
     return;
   }
@@ -226,8 +227,8 @@ Blockly.TouchGesture.prototype.handleTouchStart = function(e) {
     var point1 = this.cachedPoints_[pointers[1]];
     this.startDistance_ = goog.math.Coordinate.distance(point0, point1);
     this.isMultiTouch_ = true;
+    e.preventDefault();
   }
-  e.preventDefault();
 };
 
 /**
@@ -260,8 +261,8 @@ Blockly.TouchGesture.prototype.handleTouchMove = function(e) {
       workspace.zoom(position.x, position.y, delta);
     }
     this.previousScale_ = scale;
+    e.preventDefault();
   }
-  e.preventDefault();
 };
 
 /**

--- a/core/touch_gesture.js
+++ b/core/touch_gesture.js
@@ -101,7 +101,7 @@ Blockly.TouchGesture.ZOOM_OUT_MULTIPLIER = 6;
  */
 Blockly.TouchGesture.prototype.doStart = function(e) {
   Blockly.TouchGesture.superClass_.doStart.call(this, e);
-  if (Blockly.Touch.isTouchEvent(e)) {
+  if (!this.isEnding_ && Blockly.Touch.isTouchEvent(e)) {
     this.handleTouchStart(e);
   }
 };

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -422,7 +422,7 @@ Blockly.WorkspaceSvg.prototype.createDom = function(opt_backgroundClass) {
 
   if (!this.isFlyout) {
     Blockly.bindEventWithChecks_(this.svgGroup_, 'mousedown', this,
-        this.onMouseDown_);
+        this.onMouseDown_, false, true);
     if (this.options.zoomOptions && this.options.zoomOptions.wheel) {
       // Mouse-wheel.
       Blockly.bindEventWithChecks_(this.svgGroup_, 'wheel', this,


### PR DESCRIPTION
Chrome on touch devices fires both a pointer and a mouse down (click) event when a user taps (ie: no drag).

This is problematic as it triggers event handlers that register on 'mousedown' twice. eg: in the case of field_number's numPad hitting a key triggers the handler twice (once for PointerEvent and another for MouseEvent).

I don't see any reason to register both pointer and mouse events if the former is supported. 
@rachel-fenichel any thoughts? do you know of any reason to keep both events if pointer events are supported? or do we need the two event handlers. If so, we'll have to figure out some way to detect the 'tap' and only call the event handler once. 
