### PR TITLE
Fix flyout button alignment for Edge and firefox

### DIFF
--- a/core/flyout_button.js
+++ b/core/flyout_button.js
@@ -193,7 +193,9 @@ Blockly.FlyoutButton.prototype.createDom = function() {
     this.width += svgIcon.getComputedTextLength() + 2 * Blockly.FlyoutButton.MARGIN;
 
     svgIcon.setAttribute('text-anchor', 'end');
-    svgIcon.setAttribute('alignment-baseline', 'central');
+    svgText.setAttribute('dominant-baseline', 'central');
+    svgText.setAttribute('dy', goog.userAgent.EDGE_OR_IE ?
+      Blockly.Field.IE_TEXT_OFFSET : '0');
     svgIcon.setAttribute('x', this.targetWorkspace_.RTL ? this.width : Blockly.FlyoutButton.MARGIN);
     svgIcon.setAttribute('y', this.height / 2);
   }


### PR DESCRIPTION
Before:
(Edge)
<img width="416" alt="screen shot 2018-04-23 at 8 54 50 am" src="https://user-images.githubusercontent.com/16690124/39138089-0195cb20-46d4-11e8-94e1-d5891d6b3ec7.png">
(Firefox)
<img width="394" alt="screen shot 2018-04-23 at 8 55 51 am" src="https://user-images.githubusercontent.com/16690124/39138178-3c1b4d6a-46d4-11e8-8fa3-91f035bc4031.png">


After:
(Edge)
<img width="404" alt="screen shot 2018-04-23 at 8 52 54 am" src="https://user-images.githubusercontent.com/16690124/39138071-f53d35c0-46d3-11e8-9de8-66d16840b343.png">
(Firefox)
<img width="430" alt="screen shot 2018-04-23 at 8 56 04 am" src="https://user-images.githubusercontent.com/16690124/39138201-48da3f2a-46d4-11e8-94c1-379835e62c55.png">


Also tested on Safari and Chrome, and the dominant-baseline attribute is respected there