### PR TITLE
Fix workspace comment rendering in IE

### DIFF
--- a/core/css.js
+++ b/core/css.js
@@ -105,7 +105,7 @@ Blockly.Css.inject = function(hasCss, pathToMedia) {
       );
     }
   }
-  
+
   // Inject CSS tag at start of head.
   var cssNode = document.createElement('style');
   document.head.insertBefore(cssNode, document.head.firstChild);
@@ -573,6 +573,11 @@ Blockly.Css.CONTENT = [
     'margin: 0;',
     'padding: 0;',
     'background-color: #FAF6BD;',
+  '}',
+
+  // pxtblockly: workspace comment background in IE
+  '.blocklyUneditableMinimalBody {',
+    'fill: #FAF6BD;',
   '}',
 
   '.blocklyCommentForeignObject {',

--- a/core/workspace_comment.js
+++ b/core/workspace_comment.js
@@ -251,7 +251,7 @@ Blockly.WorkspaceComment.prototype.setWidth = function(width) {
  */
 Blockly.WorkspaceComment.prototype.isDeletable = function() {
   return this.deletable_ &&
-      !(this.workspace && this.workspace.options.readOnly || goog.userAgent.IE);
+      !(this.workspace && this.workspace.options.readOnly);
 };
 
 /**

--- a/core/workspace_comment.js
+++ b/core/workspace_comment.js
@@ -251,7 +251,7 @@ Blockly.WorkspaceComment.prototype.setWidth = function(width) {
  */
 Blockly.WorkspaceComment.prototype.isDeletable = function() {
   return this.deletable_ &&
-      !(this.workspace && this.workspace.options.readOnly);
+      !(this.workspace && this.workspace.options.readOnly || goog.userAgent.IE);
 };
 
 /**

--- a/core/workspace_comment_render_svg.js
+++ b/core/workspace_comment_render_svg.js
@@ -474,19 +474,23 @@ Blockly.WorkspaceCommentSvg.prototype.resizeComment_ = function() {
   var topOffset = Blockly.WorkspaceCommentSvg.TOP_OFFSET;
   var textOffset = Blockly.WorkspaceCommentSvg.TEXTAREA_OFFSET * 2;
 
-  if (this.foreignObject_) {
-    this.foreignObject_.setAttribute('width',
+  var backdrop = this.foreignObject_ || this.uneditableBackground_;
+
+  if (backdrop) {
+    backdrop.setAttribute('width',
         size.width);
-    this.foreignObject_.setAttribute('height',
+    backdrop.setAttribute('height',
         size.height - topOffset);
     if (this.RTL) {
-      this.foreignObject_.setAttribute('x',
+      backdrop.setAttribute('x',
           -size.width);
     }
-    this.textarea_.style.width =
-        (size.width - textOffset) + 'px';
-    this.textarea_.style.height =
-        (size.height - textOffset - topOffset) + 'px';
+    if (this.textarea_) {
+      this.textarea_.style.width =
+          (size.width - textOffset) + 'px';
+      this.textarea_.style.height =
+          (size.height - textOffset - topOffset) + 'px';
+    }
   }
 };
 
@@ -519,19 +523,22 @@ Blockly.WorkspaceCommentSvg.prototype.setSize_ = function(width, height) {
       // Mirror the resize group.
       this.resizeGroup_.setAttribute('transform', 'translate(' +
         (-width + resizeSize) + ',' + (height - resizeSize) + ') scale(-1 1)');
-      if (this.isDeletable()) {
-        this.deleteGroup_.setAttribute('transform', 'translate(' +
-          (-width + Blockly.WorkspaceCommentSvg.DELETE_ICON_PADDING) + ',' + (0) + ') scale(-1 1)');
-      }
     } else {
       this.resizeGroup_.setAttribute('transform', 'translate(' +
         (width - resizeSize) + ',' +
         (height - resizeSize) + ')');
-      if (this.isDeletable()) {
-        this.deleteGroup_.setAttribute('transform', 'translate(' +
-          (width - Blockly.WorkspaceCommentSvg.DELETE_ICON_PADDING) + ',' +
-          (0) + ')');
-      }
+    }
+  }
+
+  if (this.isDeletable()) {
+    if (this.RTL) {
+      this.deleteGroup_.setAttribute('transform', 'translate(' +
+      (-width + Blockly.WorkspaceCommentSvg.DELETE_ICON_PADDING) + ',' + (0) + ') scale(-1 1)');
+    }
+    else {
+      this.deleteGroup_.setAttribute('transform', 'translate(' +
+      (width - Blockly.WorkspaceCommentSvg.DELETE_ICON_PADDING) + ',' +
+      (0) + ')');
     }
   }
 
@@ -556,12 +563,14 @@ Blockly.WorkspaceCommentSvg.prototype.disposeInternal_ = function() {
  */
 Blockly.WorkspaceCommentSvg.prototype.setFocus = function() {
   this.focused_ = true;
-  var textarea = this.textarea_;
   this.svgRectTarget_.style.fill = "none";
   this.svgHandleTarget_.style.fill = "transparent";
-  setTimeout(function() {
-    textarea.focus();
-  }, 0);
+  if (this.textarea_) {
+    var textarea = this.textarea_;
+    setTimeout(function() {
+      textarea.focus();
+    }, 0);
+  }
   this.addFocus();
 };
 
@@ -571,12 +580,14 @@ Blockly.WorkspaceCommentSvg.prototype.setFocus = function() {
  */
 Blockly.WorkspaceCommentSvg.prototype.blurFocus = function() {
   this.focused_ = false;
-  var textarea = this.textarea_;
   this.svgRectTarget_.style.fill = "transparent";
   this.svgHandleTarget_.style.fill = "none";
-  setTimeout(function() {
-    textarea.blur();
-  }, 0);
+  if (this.textarea_) {
+    var textarea = this.textarea_;
+    setTimeout(function() {
+      textarea.blur();
+    }, 0);
+  }
   this.removeFocus();
 };
 
@@ -591,7 +602,15 @@ Blockly.WorkspaceCommentSvg.prototype.createUneditableText_ = function() {
         'class': 'blocklyUneditableComment'
       },
       this.svgGroup_);
-  this.uneditableTextLineY = 30;
+  this.uneditableBackground_ = Blockly.utils.createSvgElement(
+    'rect',
+    {
+      'class': 'blocklyUneditableMinimalBody',
+      'y': Blockly.WorkspaceCommentSvg.TOP_OFFSET.toString()
+    },
+    this.svgGroup_);
+  this.uneditableTextGroup_.appendChild(this.uneditableBackground_);
+  this.uneditableTextLineY = Blockly.WorkspaceCommentSvg.TOP_OFFSET * 2;
 };
 
 /**

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -1579,7 +1579,8 @@ Blockly.WorkspaceSvg.prototype.markFocused = function() {
 Blockly.WorkspaceSvg.prototype.setBrowserFocus = function() {
   // Blur whatever was focused since explcitly grabbing focus below does not
   // work in Edge.
-  if (document.activeElement) {
+  // pxtblockly: However, IE11 does not support blur on SVG elements
+  if (document.activeElement && document.activeElement.blur) {
     document.activeElement.blur();
   }
   try {


### PR DESCRIPTION
Background: comments in Blockly are implemented as HTML `<textArea>` elements inserted into the SVG of the workspace. IE 11 doesn't allow HTML elements to be inserted in SVGs so comments have always been readonly in IE 11

This PR brings the IE11 rendering in line with the other browsers and fixes a few exceptions that were being caused by the focus and blur events.


Before:
![comments_ie_broken](https://user-images.githubusercontent.com/13754588/43667477-e28ec520-972c-11e8-8c44-662077de0e64.gif)


After:
![comments_ie_fixed](https://user-images.githubusercontent.com/13754588/43667464-dc8a6a58-972c-11e8-9a2a-307a084d765e.gif)
