### PR TITLE
Choose connection targets based on cursor location during drag 

### DIFF
--- a/core/block_dragger.js
+++ b/core/block_dragger.js
@@ -39,9 +39,11 @@ goog.require('goog.asserts');
  * are being dragged by a mouse or touch.
  * @param {!Blockly.BlockSvg} block The block to drag.
  * @param {!Blockly.WorkspaceSvg} workspace The workspace to drag on.
+ * @param {!goog.math.Coordinate} mousedownxy Position where the mouse down
+ *          that started the drag occured in pixels (pxtblockly)
  * @constructor
  */
-Blockly.BlockDragger = function(block, workspace) {
+Blockly.BlockDragger = function(block, workspace, mousedownxy) {
   /**
    * The top block in the stack that is being dragged.
    * @type {!Blockly.BlockSvg}
@@ -62,7 +64,7 @@ Blockly.BlockDragger = function(block, workspace) {
    * @private
    */
   this.draggedConnectionManager_ = new Blockly.InsertionMarkerManager(
-      this.draggingBlock_);
+      this.draggingBlock_, this.pixelsToWorkspaceUnits_(goog.math.Coordinate.difference(mousedownxy, this.workspaceOriginInPixels_())));
 
   /**
    * Which delete area the mouse pointer is over, if any.
@@ -318,6 +320,18 @@ Blockly.BlockDragger.prototype.pixelsToWorkspaceUnits_ = function(pixelCoord) {
     result = result.scale(1 / mainScale);
   }
   return result;
+};
+
+
+/**
+ * (pxtblockly) Gets the top left of the workspace in pixels
+ * @return {!goog.math.Coordinate} The coordinate of the workspace top left in pixels
+ * @private
+ */
+Blockly.BlockDragger.prototype.workspaceOriginInPixels_ = function() {
+  var injectOrigin = goog.style.getPageOffset(this.workspace_.getInjectionDiv());
+  var wsOffset = this.workspace_.getOriginOffsetInPixels();
+  return goog.math.Coordinate.sum(injectOrigin, wsOffset);
 };
 
 /**

--- a/core/gesture.js
+++ b/core/gesture.js
@@ -462,7 +462,7 @@ Blockly.Gesture.prototype.startDraggingBlock_ = function() {
     this.duplicateOnDrag_();
   }
   this.blockDragger_ = new Blockly.BlockDragger(this.targetBlock_,
-      this.startWorkspace_);
+      this.startWorkspace_, this.mouseDownXY_);
   this.blockDragger_.startBlockDrag(this.currentDragDeltaXY_, this.healStack_);
   this.blockDragger_.dragBlock(this.mostRecentEvent_,
       this.currentDragDeltaXY_);

--- a/core/insertion_marker_manager.js
+++ b/core/insertion_marker_manager.js
@@ -150,6 +150,7 @@ Blockly.InsertionMarkerManager = function(block, handleXY) {
    */
   this.availableConnections_ = this.initAvailableConnections_();
 
+  // pxtblockly: select target connections based on user's handle on the block
   if (block.outputConnection) {
     const coord = new goog.math.Coordinate(block.outputConnection.x_, block.outputConnection.y_);
     this.handleDXY = goog.math.Coordinate.difference(handleXY, coord)
@@ -387,6 +388,7 @@ Blockly.InsertionMarkerManager.prototype.getCandidate_ = function(dxy) {
   for (var i = 0; i < this.availableConnections_.length; i++) {
     var myConnection = this.availableConnections_[i];
 
+    // pxtblockly: for output connections select the target based on the user's "handle"
     if (this.topBlock_.outputConnection === myConnection) {
       dxy = goog.math.Coordinate.sum(dxy, this.handleDXY);
     }

--- a/core/insertion_marker_manager.js
+++ b/core/insertion_marker_manager.js
@@ -38,9 +38,11 @@ goog.require('goog.math.Coordinate');
  * responsible for finding the closest eligible connection and highlighting or
  * unhiglighting it as needed during a drag.
  * @param {!Blockly.BlockSvg} block The top block in the stack being dragged.
+ * @param {!goog.math.Coordinate} handleXY Position where the mouse down
+ *          that started the drag occured in workspace units (pxtblockly)
  * @constructor
  */
-Blockly.InsertionMarkerManager = function(block) {
+Blockly.InsertionMarkerManager = function(block, handleXY) {
   Blockly.selected = block;
 
   /**
@@ -147,6 +149,14 @@ Blockly.InsertionMarkerManager = function(block) {
    * @private
    */
   this.availableConnections_ = this.initAvailableConnections_();
+
+  if (block.outputConnection) {
+    const coord = new goog.math.Coordinate(block.outputConnection.x_, block.outputConnection.y_);
+    this.handleDXY = goog.math.Coordinate.difference(handleXY, coord)
+  }
+  else {
+    this.handleDXY = new goog.math.Coordinate(0, 0);
+  }
 };
 
 /**
@@ -376,6 +386,11 @@ Blockly.InsertionMarkerManager.prototype.getCandidate_ = function(dxy) {
 
   for (var i = 0; i < this.availableConnections_.length; i++) {
     var myConnection = this.availableConnections_[i];
+
+    if (this.topBlock_.outputConnection === myConnection) {
+      dxy = goog.math.Coordinate.sum(dxy, this.handleDXY);
+    }
+
     var neighbour = myConnection.closest(radius, dxy);
     if (neighbour.connection) {
       candidateClosest = neighbour.connection;


### PR DESCRIPTION
Fixes https://github.com/Microsoft/pxt-microbit/issues/910

We have received a lot of feedback that for large blocks it's difficult to figure out what part of the block needs to overlap an input to get it to connect. In vanilla Blockly it was pretty unambiguous because you just had to line up the puzzle pieces but in Scratch blocks the left side looks just like the right.

This PR is an attempt at making that behavior feel a little more natural by basing the connection logic on the location where the user grabs the block and not the location of the output connection. 


Here is the old behavior:

![drag_offset_old](https://user-images.githubusercontent.com/13754588/43807012-5cdab876-9a5b-11e8-85f3-085c9f636cf1.gif)


Here is the new behavior:

![drag_offset_new](https://user-images.githubusercontent.com/13754588/43807014-601c6322-9a5b-11e8-8697-983c8f42be97.gif)