### PR TITLE
Adding a hover effect for reporter blocks

### DIFF
--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -80,6 +80,8 @@ Blockly.BlockSvg = function(workspace, prototypeName, opt_id) {
   Blockly.BlockSvg.superClass_.constructor.call(this,
       workspace, prototypeName, opt_id);
 
+  this.bindHoverEvents_();
+
   // Expose this block's ID on its top-level SVG group.
   if (this.svgGroup_.dataset) {
     this.svgGroup_.dataset.id = this.id;
@@ -1456,3 +1458,26 @@ Blockly.BlockSvg.prototype.scheduleSnapAndBump = function() {
     Blockly.Events.setGroup(false);
   }, Blockly.BUMP_DELAY);
 };
+
+/**
+ * pxtblockly
+ * Binds mouse events to handle the highlighting of reporter blocks
+ * @private
+ */
+Blockly.BlockSvg.prototype.bindHoverEvents_ = function() {
+  var that = this;
+  Blockly.bindEvent_(this.svgGroup_, 'mouseover', null, function(e) {
+    var target = that;
+    if (that.isShadow_ && that.parentBlock_) {
+      target = that.parentBlock_;
+    }
+    if (target.parentBlock_ && target.outputConnection) {
+      Blockly.utils.addClass(/** @type {!Element} */ (target.svgPath_), 'hover-emphasis');
+    }
+    e.stopPropagation();
+  });
+
+  Blockly.bindEvent_(this.svgGroup_, 'mouseout', null, function(e) {
+    Blockly.utils.removeClass(/** @type {!Element} */ (that.svgPath_), 'hover-emphasis');
+  });
+}

--- a/core/css.js
+++ b/core/css.js
@@ -364,8 +364,15 @@ Blockly.Css.CONTENT = [
     'stroke-width: 4px;',
   '}',
 
+  // pxtblockly: highlight reporter blocks on hover
   '.blocklyPath {',
     'stroke-width: 1px;',
+    'transition: stroke .4s;',
+  '}',
+
+  '.blocklyPath.hover-emphasis {',
+    'stroke-width: 2px;',
+    'stroke: white;',
   '}',
 
   '.blocklySelected>.blocklyPath {',


### PR DESCRIPTION
This is to address the "I can't tell where one block ends and the other begins issue". The outline only shows for nested reporter blocks.

![hover_outline](https://user-images.githubusercontent.com/13754588/45458241-9d522480-b6a7-11e8-8673-27b0c5a278d6.gif)


Tested (briefly) in Chrome, Firefox, IE, and Edge. This does not affect tooltips.