### PR TITLE
Fix issue with removing the else clause when there was a block connected in that input

### DIFF
--- a/blocks/logic.js
+++ b/blocks/logic.js
@@ -118,7 +118,7 @@ Blockly.Blocks['controls_if'] = {
       Blockly.Mutator.reconnect(this.valueConnections_[i], this, 'IF' + i);
       Blockly.Mutator.reconnect(this.statementConnections_[i], this, 'DO' + i);
     }
-    Blockly.Mutator.reconnect(this.elseStatementConnection_, this, 'ELSE');
+    if (this.getInput('ELSE')) Blockly.Mutator.reconnect(this.elseStatementConnection_, this, 'ELSE');
   },
   addElse_: function() {
     this.storeConnections_();


### PR DESCRIPTION
In an if-else statement, when a user tried to remove an else clause and there was a block connected to the if block, it would cause an exception because we were trying to reconnect a block to an input that no longer existed. 

This checks for that input before attempting to reconnect the else clause.

Fixes https://github.com/Microsoft/pxt-ev3/issues/804
