### PR TITLE
Change field dropdown cursor to pointer

### DIFF
--- a/core/field_dropdown.js
+++ b/core/field_dropdown.js
@@ -81,7 +81,7 @@ Blockly.FieldDropdown.CHECKMARK_OVERHANG = 25;
 /**
  * Mouse cursor style when over the hotspot that initiates the editor.
  */
-Blockly.FieldDropdown.prototype.CURSOR = 'default';
+Blockly.FieldDropdown.prototype.CURSOR = 'pointer';
 
 /**
  * Closure menu item currently selected.


### PR DESCRIPTION
Hard to take a screenshot of this change, but this changes the mouse pointer to be a 'pointer' instead of the default when hovering over the dropdown field.