### PR TITLE
Update selection highlight filter

### DIFF
--- a/core/block_render_svg.js
+++ b/core/block_render_svg.js
@@ -539,7 +539,9 @@ Blockly.BlockSvg.prototype.updateColour = function() {
  */
 Blockly.BlockSvg.prototype.highlightForReplacement = function(add) {
   if (add) {
-    this.svgPath_.setAttribute('filter', 'url(#blocklyReplacementGlowFilter)');
+    var replacementGlowFilterId = this.workspace.options.replacementGlowFilterId
+      || 'blocklyReplacementGlowFilter';
+    this.svgPath_.setAttribute('filter', 'url(#' + replacementGlowFilterId + ')');
     Blockly.utils.addClass(/** @type {!Element} */ (this.svgGroup_),
         'blocklyReplaceable');
   } else {
@@ -564,8 +566,10 @@ Blockly.BlockSvg.prototype.highlightShapeForInput = function(conn, add) {
     return;
   }
   if (add) {
+    var replacementGlowFilterId = this.workspace.options.replacementGlowFilterId
+      || 'blocklyReplacementGlowFilter';
     input.outlinePath.setAttribute('filter',
-        'url(#blocklyReplacementGlowFilter)');
+        'url(#' + replacementGlowFilterId + ')');
     Blockly.utils.addClass(/** @type {!Element} */ (this.svgGroup_),
         'blocklyReplaceable');
   } else {

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -257,7 +257,8 @@ Blockly.BlockSvg.prototype.setGlowStack = function(isGlowingStack) {
   // Update the applied SVG filter if the property has changed
   var svg = this.getSvgRoot();
   if (this.isGlowingStack_ && !svg.hasAttribute('filter')) {
-    svg.setAttribute('filter', 'url(#blocklyStackGlowFilter)');
+    var stackGlowFilterId = Blockly.mainWorkspace.options.stackGlowFilterId || 'blocklyStackGlowFilter';
+    svg.setAttribute('filter', 'url(#' + stackGlowFilterId + ')');
   } else if (!this.isGlowingStack_ && svg.hasAttribute('filter')) {
     svg.removeAttribute('filter');
   }
@@ -276,9 +277,10 @@ Blockly.BlockSvg.prototype.setHighlightWarning = function(isHighlightingWarning)
   // Update the applied SVG filter if the property has changed
   // var svg = this.svgPath_;
   if (this.isHighlightingWarningBlock_ && !this.svgPathWarningHighlight_) {
+    var warningGlowFilterId = Blockly.mainWorkspace.options.warningGlowFilterId || 'blocklyHighlightWarningFilter';
     this.svgPathWarningHighlight_ = this.svgPath_.cloneNode(true);
     this.svgPathWarningHighlight_.setAttribute('fill', 'none');
-    this.svgPathWarningHighlight_.setAttribute('filter', 'url(#blocklyHighlightWarningFilter)');
+    this.svgPathWarningHighlight_.setAttribute('filter', 'url(#' + warningGlowFilterId + ')');
     this.getSvgRoot().appendChild(this.svgPathWarningHighlight_);
   } else if (!this.isHighlightingWarningBlock_ && this.svgPathWarningHighlight_) {
     this.getSvgRoot().removeChild(this.svgPathWarningHighlight_);
@@ -299,9 +301,10 @@ Blockly.BlockSvg.prototype.setHighlightBlock = function(isHighlightingBlock) {
   // Update the applied SVG filter if the property has changed
   // var svg = this.svgPath_;
   if (this.isHighlightingBlock_ && !this.svgPathHighlight_) {
+    var highlightGlowFilterId = Blockly.mainWorkspace.options.highlightGlowFilterId || 'blocklyHighlightGlowFilter';
     this.svgPathHighlight_ = this.svgPath_.cloneNode(true);
     this.svgPathHighlight_.setAttribute('fill', 'none');
-    this.svgPathHighlight_.setAttribute('filter', 'url(#blocklyHighlightGlowFilter)');
+    this.svgPathHighlight_.setAttribute('filter', 'url(#' + highlightGlowFilterId + ')');
     this.getSvgRoot().appendChild(this.svgPathHighlight_);
   } else if (!this.isHighlightingBlock_ && this.svgPathHighlight_) {
     this.getSvgRoot().removeChild(this.svgPathHighlight_);
@@ -321,13 +324,14 @@ Blockly.BlockSvg.prototype.setSelectedBlock = function(isSelectingBlock) {
   this.isSelectingBlock_ = isSelectingBlock;
   // Update the applied SVG filter if the property has changed
   // var svg = this.svgPath_;
+  var svg = this.getSvgRoot();
   if (this.isSelectingBlock_ && !this.svgPathSelected_) {
+    var selectedGlowFilterId = Blockly.mainWorkspace.options.selectedGlowFilterId || 'blocklySelectedGlowFilter';
     this.svgPathSelected_ = this.svgPath_.cloneNode(true);
-    this.svgPathSelected_.setAttribute('fill', 'none');
-    this.svgPathSelected_.setAttribute('filter', 'url(#blocklySelectedGlowFilter)');
-    this.getSvgRoot().appendChild(this.svgPathSelected_);
+    this.svgPathSelected_.setAttribute('filter', 'url(#' + selectedGlowFilterId + ')');
+    svg.insertBefore(this.svgPathSelected_, svg.firstChild);
   } else if (!this.isSelectingBlock_ && this.svgPathSelected_) {
-    this.getSvgRoot().removeChild(this.svgPathSelected_);
+    svg.removeChild(this.svgPathSelected_);
     this.svgPathSelected_ = null;
   }
 };

--- a/core/colours.js
+++ b/core/colours.js
@@ -48,7 +48,7 @@ Blockly.Colours = {
   "highlightGlowSize": 1.1,
   "highlightGlowOpacity": 1,
   "selectedGlow": "#FFF200",
-  "selectedGlowSize": 0.4,
+  "selectedGlowSize": 1,
   "warningGlow": "#E53D00",
   "warningGlowSize": 1.1,
   "warningGlowOpacity": 1,

--- a/core/inject.js
+++ b/core/inject.js
@@ -131,55 +131,118 @@ Blockly.createDom_ = function(container, options) {
   // Using a dilate distorts the block shape.
   // Instead use a gaussian blur, and then set all alpha to 1 with a transfer.
   var stackGlowFilter = Blockly.utils.createSvgElement('filter',
-      {'id': 'blocklyStackGlowFilter',
-        'height': '160%', 'width': '180%', y: '-30%', x: '-40%'}, defs);
+      {
+        'id': 'blocklyStackGlowFilter' + rnd,
+        'height': '160%',
+        'width': '180%',
+        y: '-30%',
+        x: '-40%'
+      },
+      defs);
   options.stackGlowBlur = Blockly.utils.createSvgElement('feGaussianBlur',
-      {'in': 'SourceGraphic',
-        'stdDeviation': Blockly.Colours.stackGlowSize}, stackGlowFilter);
+      {
+        'in': 'SourceGraphic',
+        'stdDeviation': Blockly.Colours.stackGlowSize
+      },
+      stackGlowFilter);
   // Set all gaussian blur pixels to 1 opacity before applying flood
   var componentTransfer = Blockly.utils.createSvgElement('feComponentTransfer', {'result': 'outBlur'}, stackGlowFilter);
   Blockly.utils.createSvgElement('feFuncA',
-      {'type': 'table', 'tableValues': '0' + goog.string.repeat(' 1', 16)}, componentTransfer);
+      {
+        'type': 'table',
+        'tableValues': '0' + goog.string.repeat(' 1', 16)
+      },
+      componentTransfer);
   // Color the highlight
   Blockly.utils.createSvgElement('feFlood',
-      {'flood-color': Blockly.Colours.stackGlow,
-        'flood-opacity': Blockly.Colours.stackGlowOpacity, 'result': 'outColor'}, stackGlowFilter);
+      {
+        'flood-color': Blockly.Colours.stackGlow,
+        'flood-opacity': Blockly.Colours.stackGlowOpacity,
+        'result': 'outColor'
+      },
+      stackGlowFilter);
   Blockly.utils.createSvgElement('feComposite',
-      {'in': 'outColor', 'in2': 'outBlur',
-        'operator': 'in', 'result': 'outGlow'}, stackGlowFilter);
+      {
+        'in': 'outColor',
+        'in2': 'outBlur',
+        'operator': 'in',
+        'result': 'outGlow'
+      },
+      stackGlowFilter);
   Blockly.utils.createSvgElement('feComposite',
-      {'in': 'SourceGraphic', 'in2': 'outGlow', 'operator': 'over'}, stackGlowFilter);
+      {
+        'in': 'SourceGraphic',
+        'in2': 'outGlow',
+        'operator': 'over'
+      },
+      stackGlowFilter);
 
   // Filter for replacement marker
   var replacementGlowFilter = Blockly.utils.createSvgElement('filter',
-      {'id': 'blocklyReplacementGlowFilter',
-        'height': '160%', 'width': '180%', y: '-30%', x: '-40%'}, defs);
+      {
+        'id': 'blocklyReplacementGlowFilter' + rnd,
+        'height': '160%',
+        'width': '180%',
+        y: '-30%',
+        x: '-40%'
+      },
+      defs);
   Blockly.utils.createSvgElement('feGaussianBlur',
-      {'in': 'SourceGraphic',
-        'stdDeviation': Blockly.Colours.replacementGlowSize}, replacementGlowFilter);
+      {
+        'in': 'SourceGraphic',
+        'stdDeviation': Blockly.Colours.replacementGlowSize
+      },
+      replacementGlowFilter);
   // Set all gaussian blur pixels to 1 opacity before applying flood
   var componentTransfer = Blockly.utils.createSvgElement('feComponentTransfer',
       {'result': 'outBlur'}, replacementGlowFilter);
   Blockly.utils.createSvgElement('feFuncA',
-      {'type': 'table', 'tableValues': '0' + goog.string.repeat(' 1', 16)}, componentTransfer);
+      {
+        'type': 'table',
+        'tableValues': '0' + goog.string.repeat(' 1', 16)
+      },
+      componentTransfer);
   // Color the highlight
   Blockly.utils.createSvgElement('feFlood',
-      {'flood-color': Blockly.Colours.replacementGlow,
-        'flood-opacity': Blockly.Colours.replacementGlowOpacity, 'result': 'outColor'}, replacementGlowFilter);
+      {
+        'flood-color': Blockly.Colours.replacementGlow,
+        'flood-opacity': Blockly.Colours.replacementGlowOpacity,
+        'result': 'outColor'
+      },
+      replacementGlowFilter);
   Blockly.utils.createSvgElement('feComposite',
-      {'in': 'outColor', 'in2': 'outBlur',
-        'operator': 'in', 'result': 'outGlow'}, replacementGlowFilter);
+      {
+        'in': 'outColor',
+        'in2': 'outBlur',
+        'operator': 'in',
+        'result': 'outGlow'
+      },
+      replacementGlowFilter);
   Blockly.utils.createSvgElement('feComposite',
-      {'in': 'SourceGraphic', 'in2': 'outGlow', 'operator': 'over'}, replacementGlowFilter);
+      {
+        'in': 'SourceGraphic',
+        'in2': 'outGlow',
+        'operator': 'over'
+      },
+      replacementGlowFilter);
 
-  // Using a dilate distorts the block shape.
-  // Instead use a gaussian blur, and then set all alpha to 1 with a transfer.
+
+  // Filter for highlighting
   var highlightGlowFilter = Blockly.utils.createSvgElement('filter',
-      {'id': 'blocklyHighlightGlowFilter',
-        'height': '160%', 'width': '180%', y: '-30%', x: '-40%'}, defs);
-  options.stackGlowBlur = Blockly.utils.createSvgElement('feGaussianBlur',
-      {'in': 'SourceGraphic',
-        'stdDeviation': Blockly.Colours.highlightGlowSize}, highlightGlowFilter);
+      {
+        'id': 'blocklyHighlightGlowFilter' + rnd,
+        'height': '160%',
+        'width': '180%',
+        y: '-30%',
+        x: '-40%'
+      },
+      defs);
+  options.highlightGlowBlur = Blockly.utils.createSvgElement('feGaussianBlur',
+      {
+        'in': 'SourceGraphic',
+        'stdDeviation': Blockly.Colours.highlightGlowSize
+      },
+      highlightGlowFilter);
   // Set all gaussian blur pixels to 1 opacity before applying flood
   var componentTransfer = Blockly.utils.createSvgElement('feComponentTransfer', {'result': 'outBlur'}, highlightGlowFilter);
   Blockly.utils.createSvgElement('feFuncA',
@@ -194,11 +257,20 @@ Blockly.createDom_ = function(container, options) {
 
   // Filter for error / warning marker
   var warningGlowFilter = Blockly.utils.createSvgElement('filter',
-      {'id': 'blocklyHighlightWarningFilter',
-        'height': '160%', 'width': '180%', y: '-30%', x: '-40%'}, defs);
-  options.stackGlowBlur = Blockly.utils.createSvgElement('feGaussianBlur',
-      {'in': 'SourceGraphic',
-        'stdDeviation': Blockly.Colours.warningGlowSize}, warningGlowFilter);
+      {
+        'id': 'blocklyHighlightWarningFilter' + rnd,
+        'height': '160%',
+        'width': '180%',
+        y: '-30%',
+        x: '-40%'
+      },
+      defs);
+  options.highlightGlowBlur = Blockly.utils.createSvgElement('feGaussianBlur',
+      {
+        'in': 'SourceGraphic',
+        'stdDeviation': Blockly.Colours.warningGlowSize
+      },
+      warningGlowFilter);
   // Set all gaussian blur pixels to 1 opacity before applying flood
   var componentTransfer = Blockly.utils.createSvgElement('feComponentTransfer', {'result': 'outBlur'}, warningGlowFilter);
   Blockly.utils.createSvgElement('feFuncA',
@@ -212,22 +284,52 @@ Blockly.createDom_ = function(container, options) {
         'operator': 'in', 'result': 'outGlow'}, warningGlowFilter);
 
   var selectedGlowFilter = Blockly.utils.createSvgElement('filter',
-      {'id': 'blocklySelectedGlowFilter',
-        'height': '140%', 'width': '140%', y: '-20%', x: '-20%'}, defs);
-  options.stackGlowBlur = Blockly.utils.createSvgElement('feGaussianBlur',
-      {'in': 'SourceGraphic',
-        'stdDeviation': Blockly.Colours.selectedGlowSize}, selectedGlowFilter);
+      {
+        'id': 'blocklySelectedGlowFilter' + rnd,
+        'height': '160%',
+        'width': '180%',
+        y: '-30%',
+        x: '-40%',
+        'color-interpolation-filters': 'sRGB'
+      },
+      defs);
+  options.selectedGlowBlur = Blockly.utils.createSvgElement('feGaussianBlur',
+      {
+        'in': 'SourceGraphic',
+        'stdDeviation': Blockly.Colours.selectedGlowSize
+      },
+      selectedGlowFilter);
   // Set all gaussian blur pixels to 1 opacity before applying flood
   var componentTransfer = Blockly.utils.createSvgElement('feComponentTransfer', {'result': 'outBlur'}, selectedGlowFilter);
   Blockly.utils.createSvgElement('feFuncA',
-      {'type': 'table', 'tableValues': '0' + goog.string.repeat(' 1', 16)}, componentTransfer);
+      {
+        'type': 'table',
+        'tableValues': '0' + goog.string.repeat(' 1', 16)
+      },
+      componentTransfer);
   // Color the highlight
   Blockly.utils.createSvgElement('feFlood',
-      {'flood-color': Blockly.Colours.selectedGlow,
-        'flood-opacity': '1.0', 'result': 'outColor'}, selectedGlowFilter);
+      {
+        'flood-color': Blockly.Colours.selectedGlow,
+        'flood-opacity': '1.0',
+        'result': 'outColor'
+      },
+      selectedGlowFilter);
   Blockly.utils.createSvgElement('feComposite',
-      {'in': 'outColor', 'in2': 'outBlur',
-        'operator': 'in', 'result': 'outGlow'}, selectedGlowFilter);
+      {
+        'in': 'outColor',
+        'in2': 'outBlur',
+        'operator': 'in',
+        'result': 'outGlow'
+      },
+      selectedGlowFilter);
+  Blockly.utils.createSvgElement('feComposite',
+      {
+        'in': 'SourceGraphic',
+        'in2': 'outGlow',
+        'operator': 'over'
+      },
+      selectedGlowFilter);
 
   /*
     <filter id="blocklyEmbossFilter837493">
@@ -295,8 +397,13 @@ Blockly.createDom_ = function(container, options) {
       {'width': 10, 'height': 10, 'fill': '#aaa'}, disabledPattern);
   Blockly.utils.createSvgElement('path',
       {'d': 'M 0 0 L 10 10 M 10 0 L 0 10', 'stroke': '#cc0'}, disabledPattern);
-  options.disabledPatternId = disabledPattern.id;
 
+  options.stackGlowFilterId = stackGlowFilter.id;
+  options.replacementGlowFilterId = replacementGlowFilter.id;
+  options.highlightGlowFilterId = highlightGlowFilter.id;
+  options.warningGlowFilterId = warningGlowFilter.id;
+  options.selectedGlowFilterId = selectedGlowFilter.id;
+  options.disabledPatternId = disabledPattern.id;
   options.gridPattern = Blockly.Grid.createDom(rnd, options.gridOptions, defs);
   return svg;
 };

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -1818,6 +1818,11 @@ Blockly.WorkspaceSvg.prototype.updateStackGlowScale_ = function() {
         Blockly.STACK_GLOW_RADIUS / this.scale
     );
   }
+  if (this.options.selectedGlowBlur) {
+    this.options.selectedGlowBlur.setAttribute('stdDeviation',
+        Blockly.STACK_GLOW_RADIUS / this.scale
+    );
+  }
 };
 
 /**


### PR DESCRIPTION
There's an issue with the current selection where Safari doesn't respect blue stdDeviation between 0 and 1. More details on the issue: https://stackoverflow.com/questions/29036829/safari-svg-gaussian-blur-fegaussianblur-wont-render-stddeviation-less-than-1

Updating the selection so that it applies a blur of 1 STD but behind the path of the currently selected block rather than in front. 

This change also updates all filters to use IDs, which will be useful for when adding multiple Blockly instances on the one page, as well as fixes some re-draw issues we've seen with Electron apps and filters.
