### PR TITLE
Update widget div positioning logic to not cut off content above the screen

### DIFF
--- a/core/widgetdiv.js
+++ b/core/widgetdiv.js
@@ -307,6 +307,10 @@ Blockly.WidgetDiv.calculateY_ = function(viewportBBox, anchorBBox, widgetSize) {
   // Flip the widget vertically if off the bottom.
   if (anchorBBox.bottom + widgetSize.height >=
       viewportBBox.bottom) {
+    if (anchorBBox.bottom - widgetSize.height <= viewportBBox.top) {
+      // The top of the widget is at the top of the viewport.
+      return viewportBBox.top;
+    }
     // The bottom of the widget is at the top of the field.
     return anchorBBox.top - widgetSize.height;
     // The widget could go off the top of the window, but it would also go off

--- a/typings/blockly.d.ts
+++ b/typings/blockly.d.ts
@@ -634,7 +634,6 @@ declare namespace Blockly {
         onItemSelected(menu: goog.ui.Menu, menuItem: goog.ui.MenuItem): void;
         positionArrow(x: number): number;
         shouldShowRect_(): boolean;
-        getAnchorDimensions_(): goog.math.Box;
     }
 
     class FieldNumber extends FieldTextInput {


### PR DESCRIPTION
The current positioning of the widget div would rather show content close to the top of the field and have it cut off the top of the screen, than show it above the entire field. 

Changing this logic to show content above a field in that case. 
Here's an example: 

![screen shot 2018-10-10 at 6 03 36 pm](https://user-images.githubusercontent.com/16690124/46774357-d980a100-ccb6-11e8-8f34-eafe465d1231.png)
