### PR TITLE
Darken shadow field input when the menu is open

### DIFF
--- a/core/block.js
+++ b/core/block.js
@@ -257,6 +257,13 @@ Blockly.Block.prototype.colourSecondary_ = '#FF0000';
 Blockly.Block.prototype.colourTertiary_ = '#FF0000';
 
 /**
+ * Fill colour used to override default shadow colour behaviour.
+ * @type {string}
+ * @private
+ */
+Blockly.Block.prototype.shadowColour_ = null;
+
+/**
  * Colour of the block as HSV hue value (0-360)
  * @type {?number}
  * @private
@@ -817,6 +824,35 @@ Blockly.Block.prototype.getColourSecondary = function() {
  */
 Blockly.Block.prototype.getColourTertiary = function() {
   return this.colourTertiary_;
+};
+
+/**
+ * Get the shadow colour of a block.
+ * @return {string} #RRGGBB string.
+ */
+Blockly.Block.prototype.getShadowColour = function() {
+  return this.shadowColour_;
+};
+
+/**
+ * Set the shadow colour of a block.
+ * @param {number|string} colour HSV hue value, or #RRGGBB string.
+ */
+Blockly.Block.prototype.setShadowColour = function(colour) {
+  this.shadowColour_ = this.makeColour_(colour);
+  if (this.rendered) {
+    this.updateColour();
+  }
+};
+
+/**
+ * Clear the shadow colour of a block.
+ */
+Blockly.Block.prototype.clearShadowColour = function() {
+  this.shadowColour_ = null;
+  if (this.rendered) {
+    this.updateColour();
+  }
 };
 
 /**

--- a/core/block_render_svg.js
+++ b/core/block_render_svg.js
@@ -482,8 +482,7 @@ Blockly.BlockSvg.SHAPE_IN_SHAPE_PADDING = {
  */
 Blockly.BlockSvg.prototype.updateColour = function() {
   var strokeColour = this.getColourTertiary();
-  var renderShadowed =
-      this.isShadow() && !Blockly.utils.isShadowArgumentReporter(this);
+  var renderShadowed = this.isShadow() && !Blockly.utils.isShadowArgumentReporter(this);
 
   if (renderShadowed && this.parentBlock_) {
     // Pull shadow block stroke colour from parent block's tertiary if possible.
@@ -503,6 +502,10 @@ Blockly.BlockSvg.prototype.updateColour = function() {
   // Render block fill
   if (this.isGlowingBlock_ || renderShadowed) {
     var fillColour = this.getColourSecondary();
+    // Special case: if we have set a shadow colour on the block, use that instead
+    if (this.getShadowColour()) {
+      fillColour = this.getShadowColour();
+    }
   } else {
     var fillColour = this.getColour();
   }

--- a/core/field_dropdown.js
+++ b/core/field_dropdown.js
@@ -325,9 +325,7 @@ Blockly.FieldDropdown.prototype.showEditor_ = function() {
   // Update colour to look selected.
   if (!this.disableColourChange_) {
     if (this.sourceBlock_.isShadow()) {
-      this.savedPrimary_ = this.sourceBlock_.getColour();
-      this.sourceBlock_.setColour(this.sourceBlock_.getColourTertiary(),
-          this.sourceBlock_.getColourSecondary(), this.sourceBlock_.getColourTertiary());
+      this.sourceBlock_.setShadowColour(this.sourceBlock_.getColourTertiary());
     } else if (this.box_) {
       this.box_.setAttribute('fill', this.sourceBlock_.getColourTertiary());
     }
@@ -342,8 +340,7 @@ Blockly.FieldDropdown.prototype.onHide = function() {
   // Update colour to look selected.
   if (!this.disableColourChange_ && this.sourceBlock_) {
     if (this.sourceBlock_.isShadow()) {
-      this.sourceBlock_.setColour(this.savedPrimary_,
-          this.sourceBlock_.getColourSecondary(), this.sourceBlock_.getColourTertiary());
+      this.sourceBlock_.clearShadowColour();
     } else if (this.box_) {
       this.box_.setAttribute('fill', this.sourceBlock_.getColour());
     }


### PR DESCRIPTION
In the same way that we darken menu dropdowns when a field is on a block. Do it when it's a shadow block. 

![shadowdropdown](https://user-images.githubusercontent.com/16690124/46824318-4e022100-cd45-11e8-9e7b-2a10c499ed6b.gif)
