### PR TITLE
Fix horizontal scrolling of DropdownDiv

### DIFF
--- a/core/css.js
+++ b/core/css.js
@@ -242,6 +242,7 @@ Blockly.Css.CONTENT = [
   '.blocklyDropDownContent {',
     'max-height: 300px;', // @todo: spec for maximum height.
     'overflow: auto;',
+    'overflow-x: hidden;',
   '}',
 
   '.blocklyDropDownArrow {',


### PR DESCRIPTION
Fix horizontal scrolling of DropdownDiv on Safari and Edge.

Fixes this issue:
![39650908-c28acbfa-4f9e-11e8-91bf-3bc2d64e6067](https://user-images.githubusercontent.com/16690124/46837002-8f57f800-cd68-11e8-8abd-28a6169cc22d.png)
