### PR TITLE
Fix flickering issues on hover in the flyout

### DIFF
--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -1499,16 +1499,21 @@ Blockly.BlockSvg.prototype.bindHoverEvents_ = function() {
   var that = this;
   Blockly.bindEvent_(this.svgGroup_, 'mouseover', null, function(e) {
     var target = that;
+    if (target.isInFlyout) return;
+
     if (that.isShadow_ && that.parentBlock_) {
       target = that.parentBlock_;
     }
     if (target.parentBlock_ && target.outputConnection) {
       Blockly.utils.addClass(/** @type {!Element} */ (target.svgPath_), 'hover-emphasis');
+      e.stopPropagation();
     }
-    e.stopPropagation();
   });
 
   Blockly.bindEvent_(this.svgGroup_, 'mouseout', null, function(/*e*/) {
+    var target = that;
+    if (target.isInFlyout) return;
+
     Blockly.utils.removeClass(/** @type {!Element} */ (that.svgPath_), 'hover-emphasis');
   });
 };

--- a/core/flyout_base.js
+++ b/core/flyout_base.js
@@ -544,13 +544,13 @@ Blockly.Flyout.prototype.addBlockListeners_ = function(root, block, rect) {
       this.blockMouseDown_(block)));
   this.listeners_.push(Blockly.bindEventWithChecks_(rect, 'mousedown', null,
       this.blockMouseDown_(block)));
-  this.listeners_.push(Blockly.bindEvent_(root, 'mouseover', block,
+  this.listeners_.push(Blockly.bindEvent_(root, 'mouseenter', block,
       block.addSelect));
-  this.listeners_.push(Blockly.bindEvent_(root, 'mouseout', block,
+  this.listeners_.push(Blockly.bindEvent_(root, 'mouseleave', block,
       block.removeSelect));
-  this.listeners_.push(Blockly.bindEvent_(rect, 'mouseover', block,
+  this.listeners_.push(Blockly.bindEvent_(rect, 'mouseenter', block,
       block.addSelect));
-  this.listeners_.push(Blockly.bindEvent_(rect, 'mouseout', block,
+  this.listeners_.push(Blockly.bindEvent_(rect, 'mouseleave', block,
       block.removeSelect));
 };
 
@@ -698,12 +698,10 @@ Blockly.Flyout.prototype.moveRectToBlock_ = function(rect, block) {
     block.moveBy(0, hatOffset);
   }
 
-  // Blocks with output tabs are shifted a bit.
-  var tab = block.outputConnection ? Blockly.BlockSvg.TAB_WIDTH : 0;
   var blockXY = block.getRelativeToSurfaceXY();
   rect.setAttribute('y', blockXY.y);
   rect.setAttribute('x',
-      this.RTL ? blockXY.x - blockHW.width + tab : blockXY.x - tab);
+      this.RTL ? blockXY.x - blockHW.width : blockXY.x);
 };
 
 /**


### PR DESCRIPTION
Here's are the issues: 
![hoverconflict](https://user-images.githubusercontent.com/16690124/46963660-194edc00-d05b-11e8-8235-21325f4fe853.gif)
![flickeringonhover](https://user-images.githubusercontent.com/16690124/46963543-cbd26f00-d05a-11e8-9af6-98e6424adfee.gif)

There are a couple of issues here. The first is a conflict between the hover effect code added for reporter blocks in https://github.com/Microsoft/pxt-blockly/pull/115 and flyout hover code. The new code adds a stoppropagation which doesn't let the event get to the hover code in the flyout. This code is unnecessary in the flyout so I'm skipping it when the block is in the flyout. I'm also only stopping propagation if there's a hit. 

Another issue was that there's a fine line between the block SVG root and the imaginary pad added behind it in the flyout as a click target which was causing the flickering issue. I got around that by using mouseenter and leave events instead of over and out. 
