### PR TITLE
Transition animation when centering on a block

### DIFF
--- a/core/colours.js
+++ b/core/colours.js
@@ -61,5 +61,7 @@ Blockly.Colours = {
   "numPadActiveBackground": "#435F91",
   "numPadText": "#FFFFFF",
   "valueReportBackground": "#FFFFFF",
-  "valueReportBorder": "#AAAAAA"
+  "valueReportBorder": "#AAAAAA",
+  // Center on block transition
+  "canvasTransitionLength": 500
 };

--- a/core/css.js
+++ b/core/css.js
@@ -212,6 +212,10 @@ Blockly.Css.CONTENT = [
     'z-index: 50;', /* Display above the toolbox */
   '}',
 
+  '.blocklyBlockCanvas.blocklyTransitioning {',
+    'transition: all 0.5s ease-in-out;',
+  '}',
+
   '.blocklyTooltipDiv {',
     'background-color: #ffffc7;',
     'border: 1px solid #ddc;',

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -1705,9 +1705,10 @@ Blockly.WorkspaceSvg.prototype.scrollCenter = function() {
 /**
  * Scroll the workspace to center on the given block.
  * @param {?string} id ID of block center on.
+ * @param {boolean} animate If true, transition to the block.
  * @public
  */
-Blockly.WorkspaceSvg.prototype.centerOnBlock = function(id) {
+Blockly.WorkspaceSvg.prototype.centerOnBlock = function(id, animate) {
   if (!this.scrollbar) {
     console.warn('Tried to scroll a non-scrollable workspace.');
     return;
@@ -1716,6 +1717,11 @@ Blockly.WorkspaceSvg.prototype.centerOnBlock = function(id) {
   var block = this.getBlockById(id);
   if (!block) {
     return;
+  }
+
+  // If we're animating, apply a transition class to the workspace
+  if (animate) {
+    Blockly.utils.addClass(this.svgBlockCanvas_, 'blocklyTransitioning');
   }
 
   // XY is in workspace coordinates.
@@ -1755,6 +1761,11 @@ Blockly.WorkspaceSvg.prototype.centerOnBlock = function(id) {
 
   Blockly.hideChaff();
   this.scrollbar.set(scrollToCenterX, scrollToCenterY);
+
+  var blockCanvas = this.svgBlockCanvas_;
+  setTimeout(function() {
+    Blockly.utils.removeClass(blockCanvas, 'blocklyTransitioning');
+  }, Blockly.Colours.canvasTransitionLength);
 };
 
 /**

--- a/tests/playground.html
+++ b/tests/playground.html
@@ -226,7 +226,7 @@ function logger(e) {
 
 function centerOnBlock() {
   if (Blockly.selected) {
-    workspace.centerOnBlock(Blockly.selected.id);
+    workspace.centerOnBlock(Blockly.selected.id, true);
   }
 }
 


### PR DESCRIPTION
Add a transition animation when moving to centre on a block in the workspace. 
![transition](https://user-images.githubusercontent.com/16690124/46963953-cfb2c100-d05b-11e8-976c-0691cc35dbb6.gif)


Note: this doesn't work in IE and Edge as they don't support SVG CSS transition on transforms.