### PR TITLE
Add hover effect to the draggable variable

### DIFF
--- a/core/gesture.js
+++ b/core/gesture.js
@@ -1004,6 +1004,7 @@ Blockly.Gesture.prototype.duplicateOnDrag_ = function() {
       newVariableField.textContent = xmlBlockField.textContent;
       newVariableBlock.appendChild(newVariableField);
       xmlBlock = newVariableBlock;
+      this.targetBlock_.inputList[0].fieldRow[0].clearHover();
     }
     newBlock = Blockly.Xml.domToBlock(xmlBlock, this.startWorkspace_);
 


### PR DESCRIPTION
Add hover effect to the draggable variable that shows a dotted outline around the variable when hovered. 
It also changes the cursor to the 'copy' cursor when hovered, see gif: 

![draggablehover](https://user-images.githubusercontent.com/16690124/47122290-0e4aa600-d22b-11e8-979c-f8652de64d5b.gif)
