### PR TITLE
Multiple connection points for wide inputs

### DIFF
--- a/core/block_render_svg.js
+++ b/core/block_render_svg.js
@@ -1279,6 +1279,9 @@ Blockly.BlockSvg.prototype.renderDrawRight_ = function(steps,
           input.connection.setOffsetInBlock(connectionX, connectionY);
           this.renderInputShape_(input, cursorX, cursorY + connectionYOffset);
           cursorX += input.renderWidth + Blockly.BlockSvg.SEP_SPACE_X;
+
+          // pxtblockly: Used for calculating multiple connection points
+          input.connection.renderedWidth_ = input.renderWidth;
         }
       }
       // Remove final separator and replace it with right-padding.

--- a/core/insertion_marker_manager.js
+++ b/core/insertion_marker_manager.js
@@ -389,11 +389,12 @@ Blockly.InsertionMarkerManager.prototype.getCandidate_ = function(dxy) {
     var myConnection = this.availableConnections_[i];
 
     // pxtblockly: for output connections select the target based on the user's "handle"
+    var offsetxy = dxy;
     if (this.topBlock_.outputConnection === myConnection) {
-      dxy = goog.math.Coordinate.sum(dxy, this.handleDXY);
+      offsetxy = goog.math.Coordinate.sum(dxy, this.handleDXY);
     }
 
-    var neighbour = myConnection.closest(radius, dxy);
+    var neighbour = myConnection.closest(radius, offsetxy);
     if (neighbour.connection) {
       candidateClosest = neighbour.connection;
       candidateLocal = myConnection;

--- a/core/rendered_connection.js
+++ b/core/rendered_connection.js
@@ -56,7 +56,15 @@ goog.inherits(Blockly.RenderedConnection, Blockly.Connection);
  * @return {number} The distance between connections, in workspace units.
  */
 Blockly.RenderedConnection.prototype.distanceFrom = function(otherConnection) {
+  // pxtblockly: Multiple connection points for wide inputs
+  if (otherConnection.renderedWidth_ && (!this.renderedWidth_ || otherConnection.renderedWidth_ > this.renderedWidth_)) {
+    return otherConnection.distanceFrom(this);
+  }
+
   var xDiff = this.x_ - otherConnection.x_;
+  if (this.renderedWidth_ > 100) {
+    xDiff = Math.min(Math.abs(xDiff), Math.abs(xDiff + (this.renderedWidth_ >> 1)), Math.abs(xDiff + this.renderedWidth_));
+  }
   var yDiff = this.y_ - otherConnection.y_;
   return Math.sqrt(xDiff * xDiff + yDiff * yDiff);
 };


### PR DESCRIPTION
![multiple-connection-points](https://user-images.githubusercontent.com/13754588/47187376-aeb2d000-d2e8-11e8-95dc-9e1e5db88cf4.gif)

I didn't see any real perf degradation with this change. Tested in the blockly playground in Edge and Chrome