### PR TITLE
Always position dropdown wherever you have the most space

### DIFF
--- a/core/dropdowndiv.js
+++ b/core/dropdowndiv.js
@@ -275,9 +275,11 @@ Blockly.DropDownDiv.getPositionMetrics = function(primaryX, primaryY, secondaryX
   // renderX, renderY will eventually be the final rendered position of the box.
   var renderX, renderY, renderedSecondary;
   // Can the div fit inside the bounds if we render below the primary point?
-  if (primaryY + divSize.height > boundPosition.top + boundSize.height) {
+  var belowOverflow = primaryY + divSize.height - (boundPosition.top + boundSize.height)
+  if (belowOverflow > 0) {
     // We can't fit below in terms of y. Can we fit above?
-    if (secondaryY - divSize.height < boundPosition.top) {
+    var aboveOverflow = secondaryY - divSize.height - boundPosition.top
+    if (belowOverflow < aboveOverflow) {
       // We also can't fit above, so just render below anyway.
       renderX = primaryX;
       renderY = primaryY + Blockly.DropDownDiv.PADDING_Y;


### PR DESCRIPTION
If the dropdown div can't fit below the block, Blockly puts it above the block instead. If it also can't fit the div above the block, it gives up and puts the div below.

This change tweaks that logic so that when there isn't enough space above and below, we choose whichever side has the most available space (instead of always below). The div still gets cut off, but the old behavior would often look pretty broken:

![image](https://user-images.githubusercontent.com/13754588/47327970-fbb5df80-d623-11e8-8ea9-f1f6ad24d6a8.png)

Now that looks more like this:

![image](https://user-images.githubusercontent.com/13754588/47328087-78e15480-d624-11e8-90af-b019931ccdcc.png)

Definitely not great but maybe better? @samelhusseini I will default to your judgement over whether or not to merge this as a holdover fix.  Ultimately we should consider a different experience for small screens; maybe a modal centered in the workspace