### PR TITLE
Don't show hover effects in readonly workspace

### DIFF
--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -80,7 +80,7 @@ Blockly.BlockSvg = function(workspace, prototypeName, opt_id) {
   Blockly.BlockSvg.superClass_.constructor.call(this,
       workspace, prototypeName, opt_id);
 
-  this.bindHoverEvents_();
+  if (!workspace.options.readOnly) this.bindHoverEvents_();
 
   // Expose this block's ID on its top-level SVG group.
   if (this.svgGroup_.dataset) {

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -80,8 +80,6 @@ Blockly.BlockSvg = function(workspace, prototypeName, opt_id) {
   Blockly.BlockSvg.superClass_.constructor.call(this,
       workspace, prototypeName, opt_id);
 
-  if (!workspace.options.readOnly) this.bindHoverEvents_();
-
   // Expose this block's ID on its top-level SVG group.
   if (this.svgGroup_.dataset) {
     this.svgGroup_.dataset.id = this.id;
@@ -184,6 +182,11 @@ Blockly.BlockSvg.prototype.initSvg = function() {
 
   if (!this.getSvgRoot().parentNode) {
     this.workspace.getCanvas().appendChild(this.getSvgRoot());
+  }
+
+  if (!this.workspace.options.readOnly && this.outputConnection) {
+    // Add hover events for reporter blocks
+    this.bindReporterHoverEvents_();
   }
 };
 
@@ -1495,14 +1498,14 @@ Blockly.BlockSvg.prototype.scheduleSnapAndBump = function() {
  * Binds mouse events to handle the highlighting of reporter blocks
  * @private
  */
-Blockly.BlockSvg.prototype.bindHoverEvents_ = function() {
+Blockly.BlockSvg.prototype.bindReporterHoverEvents_ = function() {
   var that = this;
   Blockly.bindEvent_(this.svgGroup_, 'mouseover', null, function(e) {
     var target = that;
     if (target.isInFlyout) return;
 
-    if (that.isShadow_ && that.parentBlock_) {
-      target = that.parentBlock_;
+    while (target.isShadow_ && target.parentBlock_) {
+      target = target.parentBlock_;
     }
     if (target.parentBlock_ && target.outputConnection) {
       Blockly.utils.addClass(/** @type {!Element} */ (target.svgPath_), 'hover-emphasis');

--- a/core/field_dropdown.js
+++ b/core/field_dropdown.js
@@ -160,12 +160,14 @@ Blockly.FieldDropdown.prototype.init = function() {
   this.text_ = null;
   this.setText(text);
 
-  this.mouseOverWrapper_ =
-      Blockly.bindEvent_(
-          this.getClickTarget_(), 'mouseover', this, this.onMouseOver_);
-  this.mouseOutWrapper_ =
-      Blockly.bindEvent_(
-          this.getClickTarget_(), 'mouseout', this, this.onMouseOut_);
+  if (this.sourceBlock_.isEditable()) {
+    this.mouseOverWrapper_ =
+        Blockly.bindEvent_(
+            this.getClickTarget_(), 'mouseover', this, this.onMouseOver_);
+    this.mouseOutWrapper_ =
+        Blockly.bindEvent_(
+            this.getClickTarget_(), 'mouseout', this, this.onMouseOut_);
+  }
 };
 
 /**

--- a/core/field_dropdown.js
+++ b/core/field_dropdown.js
@@ -160,7 +160,7 @@ Blockly.FieldDropdown.prototype.init = function() {
   this.text_ = null;
   this.setText(text);
 
-  if (this.sourceBlock_.isEditable()) {
+  if (this.sourceBlock_.isEditable() && this.shouldShowRect_()) {
     this.mouseOverWrapper_ =
         Blockly.bindEvent_(
             this.getClickTarget_(), 'mouseover', this, this.onMouseOver_);

--- a/core/field_slider.js
+++ b/core/field_slider.js
@@ -86,12 +86,14 @@ Blockly.FieldSlider.prototype.init = function() {
   Blockly.FieldTextInput.superClass_.init.call(this);
   this.setValue(this.getValue());
 
-  this.mouseOverWrapper_ =
-      Blockly.bindEvent_(
-          this.getClickTarget_(), 'mouseover', this, this.onMouseOver_);
-  this.mouseOutWrapper_ =
-      Blockly.bindEvent_(
-          this.getClickTarget_(), 'mouseout', this, this.onMouseOut_);
+  if (this.sourceBlock_.isEditable()) {
+    this.mouseOverWrapper_ =
+        Blockly.bindEvent_(
+            this.getClickTarget_(), 'mouseover', this, this.onMouseOver_);
+    this.mouseOutWrapper_ =
+        Blockly.bindEvent_(
+            this.getClickTarget_(), 'mouseout', this, this.onMouseOut_);
+  }
 };
 
 /**

--- a/core/field_textinput.js
+++ b/core/field_textinput.js
@@ -138,12 +138,14 @@ Blockly.FieldTextInput.prototype.init = function() {
     this.fieldGroup_.insertBefore(this.box_, this.textElement_);
   }
 
-  this.mouseOverWrapper_ =
-      Blockly.bindEvent_(
-          this.getClickTarget_(), 'mouseover', this, this.onMouseOver_);
-  this.mouseOutWrapper_ =
-      Blockly.bindEvent_(
-          this.getClickTarget_(), 'mouseout', this, this.onMouseOut_);
+  if (this.sourceBlock_.isEditable()) {
+    this.mouseOverWrapper_ =
+        Blockly.bindEvent_(
+            this.getClickTarget_(), 'mouseover', this, this.onMouseOver_);
+    this.mouseOutWrapper_ =
+        Blockly.bindEvent_(
+            this.getClickTarget_(), 'mouseout', this, this.onMouseOut_);
+  }
 };
 
 /**

--- a/core/field_textinput.js
+++ b/core/field_textinput.js
@@ -138,7 +138,8 @@ Blockly.FieldTextInput.prototype.init = function() {
     this.fieldGroup_.insertBefore(this.box_, this.textElement_);
   }
 
-  if (this.sourceBlock_.isEditable()) {
+  if (this.sourceBlock_.isEditable() &&
+    this.sourceBlock_.getOutputShape() == Blockly.OUTPUT_SHAPE_ROUND) {
     this.mouseOverWrapper_ =
         Blockly.bindEvent_(
             this.getClickTarget_(), 'mouseover', this, this.onMouseOver_);

--- a/core/field_variable_getter.js
+++ b/core/field_variable_getter.js
@@ -105,12 +105,14 @@ Blockly.FieldVariableGetter.prototype.init = function() {
   // TODO (blockly #1010): Change from init/initModel to initView/initModel
   this.initModel();
 
-  this.mouseOverWrapper_ =
-      Blockly.bindEvent_(
-          this.getClickTarget_(), 'mouseover', this, this.onMouseOver_);
-  this.mouseOutWrapper_ =
-      Blockly.bindEvent_(
-          this.getClickTarget_(), 'mouseout', this, this.onMouseOut_);
+  if (this.sourceBlock_.isEditable()) {
+    this.mouseOverWrapper_ =
+        Blockly.bindEvent_(
+            this.getClickTarget_(), 'mouseover', this, this.onMouseOver_);
+    this.mouseOutWrapper_ =
+        Blockly.bindEvent_(
+            this.getClickTarget_(), 'mouseout', this, this.onMouseOut_);
+  }
 };
 
 /**
@@ -356,7 +358,7 @@ Blockly.FieldVariableGetter.prototype.showEditor_ = function() {
  * Suppress default editable behaviour.
  */
 Blockly.FieldVariableGetter.prototype.updateEditable = function() {
-  if (!this.sourceBlock_.isInFlyout) {
+  if (!this.sourceBlock_.isInFlyout && this.sourceBlock_.isEditable()) {
     this.fieldGroup_.style.cursor = this.CURSOR;
   }
 };


### PR DESCRIPTION
Don't show hover effects on fields in a readonly workspace. 
This PR also fixes issues with the reporter hover if a shadow block is nested and it's parent is also a shadow.  @riknoll 
I'm also trying to be a little more efficient and only registering the reporter hover on blocks with an output connection, @riknoll what's the full test matrix for this?
Are you able to give this a go and make sure I didn't miss anything here?

Fixes https://github.com/Microsoft/pxt/issues/4886