### PR TITLE
Minor fix in top positioning of the field number picker

### DIFF
--- a/core/field_number.js
+++ b/core/field_number.js
@@ -82,13 +82,6 @@ Blockly.FieldNumber.fromJson = function(options) {
 Blockly.FieldNumber.DROPDOWN_WIDTH = 168;
 
 /**
- * Extra padding to add between the block and the num-pad drop-down, in px.
- * @type {number}
- * @const
- */
-Blockly.FieldNumber.DROPDOWN_Y_PADDING = 8;
-
-/**
  * Buttons for the num-pad, in order from the top left.
  * Values are strings of the number or symbol will be added to the field text
  * when the button is pressed.
@@ -210,18 +203,22 @@ Blockly.FieldNumber.prototype.showNumPad_ = function() {
  * @private
  */
 Blockly.FieldNumber.prototype.position_ = function() {
-  // Calculate positioning based on the field position.
+  // Calculate positioning for the drop-down
+  // sourceBlock_ is the rendered shadow field input box
   var scale = this.sourceBlock_.workspace.scale;
-  var bBox = {width: this.size_.width, height: this.size_.height};
+  var bBox = this.sourceBlock_.getHeightWidth();
   bBox.width *= scale;
   bBox.height *= scale;
-  var position = this.fieldGroup_.getBoundingClientRect();
-  var primaryX = position.left + bBox.width / 2;
-  var primaryY = position.top + bBox.height;
+  var position = this.getAbsoluteXY_();
+  // If we can fit it, render below the shadow block
+  var primaryX = position.x + bBox.width / 2;
+  var primaryY = position.y + bBox.height;
+  // If we can't fit it, render above the entire parent block
   var secondaryX = primaryX;
-  var secondaryY = position.top;
-  // Set bounds to workspace; show the drop-down.
-  Blockly.DropDownDiv.setBoundsElement(this.sourceBlock_.workspace.getParentSvg().parentNode);
+  var secondaryY = position.y;
+
+  Blockly.DropDownDiv.setBoundsElement(
+      this.sourceBlock_.workspace.getParentSvg().parentNode);
   Blockly.DropDownDiv.show(this, primaryX, primaryY, secondaryX, secondaryY,
       this.onHide_.bind(this));
 };


### PR DESCRIPTION
Noticed that the recent fix for the field number (https://github.com/Microsoft/pxt-blockly/pull/125) wasn't properly positioning the picker when positioned above the field, see screenshots. Following @rachel-fenichel fix in https://github.com/LLK/scratch-blocks/pull/1741

Before: 
<img width="262" alt="screen shot 2018-10-23 at 9 05 51 am" src="https://user-images.githubusercontent.com/16690124/47374605-40349000-d6a3-11e8-9967-05dc19d91995.png">

After: 
<img width="270" alt="screen shot 2018-10-23 at 9 05 39 am" src="https://user-images.githubusercontent.com/16690124/47374609-432f8080-d6a3-11e8-9009-88ab387e050e.png">

