### PR TITLE
Don’t show the reporter hover when that block is selected.

### DIFF
--- a/core/css.js
+++ b/core/css.js
@@ -375,7 +375,7 @@ Blockly.Css.CONTENT = [
   '}',
 
   // pxtblockly: highlight reporter blocks on hover
-  '.blocklyPath.blocklyReporterHover {',
+  '.blocklyDraggable:not(.blocklySelected)>.blocklyPath.blocklyReporterHover {',
     'stroke-width: 2px;',
     'stroke: white;',
   '}',


### PR DESCRIPTION
Selected outline takes precedence. 