### PR TITLE
Block click target for dropdowns with text

### DIFF
--- a/core/field.js
+++ b/core/field.js
@@ -770,8 +770,14 @@ Blockly.Field.prototype.getClickTarget_ = function() {
 
   var nFields = 0;
 
+  var nFields = 0;
+  // Count the number of fields, excluding text fields
   for (var i = 0, input; input = this.sourceBlock_.inputList[i]; i++) {
-    nFields += input.fieldRow.length;
+    for (var j = 0, field; field = input.fieldRow[j]; j++) {
+      if (!(field instanceof Blockly.FieldLabel)) {
+        nFields ++;
+      }
+    }
   }
 
   if (nFields <= 1 && this.sourceBlock_.outputConnection


### PR DESCRIPTION
Allow us to click anywhere on the field if it's just a field dropdown with text in it. 

This is for the Minecraft item / animal blocks. Clicking anywhere should open the dropdown and not just on the image of the grid picker.