### PR TITLE
Fix UI events

### DIFF
--- a/core/field_dropdown.js
+++ b/core/field_dropdown.js
@@ -345,6 +345,10 @@ Blockly.FieldDropdown.prototype.onItemSelected = function(menu, menuItem) {
   }
   if (value !== null) {
     this.setValue(value);
+
+    // pxtblockly: Fire a UI event that an edit was complete
+    Blockly.Events.fire(new Blockly.Events.Ui(
+        this.sourceBlock_, 'itemSelected', undefined, value));
   }
 };
 

--- a/core/field_textinput.js
+++ b/core/field_textinput.js
@@ -668,6 +668,9 @@ Blockly.FieldTextInput.prototype.maybeSaveEdit_ = function() {
   }
   this.setText(text);
   this.sourceBlock_.rendered && this.sourceBlock_.render();
+  // pxtblockly: Fire a UI event that an edit was complete
+  Blockly.Events.fire(new Blockly.Events.Ui(
+      this.sourceBlock_, 'saveEdit', undefined, text));
 };
 
 /**

--- a/core/toolbox.js
+++ b/core/toolbox.js
@@ -659,12 +659,8 @@ Blockly.Toolbox.TreeControl.prototype.setSelectedItem = function(node) {
     toolbox.flyout_.hide();
   }
   if (oldNode != node && oldNode != this) {
-    // pxtblockly: workaround changes to the UI event
-    var event = new Blockly.Events.Ui(null);
-    event.fromJson({
-        'element': 'category',
-        'newValue': node && node.getHtml()
-    });
+    var event = new Blockly.Events.Ui(null, 'category',
+        oldNode && oldNode.getHtml(), node && node.getHtml());
     event.workspaceId = toolbox.workspace_.id;
     Blockly.Events.fire(event);
   }

--- a/core/ui_events.js
+++ b/core/ui_events.js
@@ -42,16 +42,13 @@ goog.require('goog.math.Coordinate');
  * @constructor
  */
 Blockly.Events.Ui = function(block, element, oldValue, newValue) {
-  if (!block) {
-    return;  // Blank event to be populated by fromJson.
-  }
-
   Blockly.Events.Ui.superClass_.constructor.call(this);
-  this.blockId = block.id;
-  this.workspaceId = block.workspace.id;
+  this.blockId = block ? block.id : null;
+  this.workspaceId = block ? block.workspace.id : null;
   this.element = element;
   this.oldValue = oldValue;
   this.newValue = newValue;
+  // UI events do not undo or redo.
   this.recordUndo = false;
 };
 goog.inherits(Blockly.Events.Ui, Blockly.Events.Abstract);


### PR DESCRIPTION
UI events, for things like 'selected' where broken. Fixed UI events. 
Also added two new PXT blockly events for when the user has made their final choice in a text or dropdown field. ``saveEdit`` and ``itemSelected``. 

This is because doesn't make a save if the user is in the middle of editing a field. These events allow us to know when the user is done with editing the field even if they haven't made a change to their selected or their text.
