### PR TITLE
Reuse dropdown and quote images in SVG

### DIFF
--- a/core/field_dropdown.js
+++ b/core/field_dropdown.js
@@ -130,12 +130,18 @@ Blockly.FieldDropdown.prototype.init = function() {
   this.arrowX_ = 0;
   /** @type {Number} */
   this.arrowY_ = 11;
-  this.arrow_ = Blockly.utils.createSvgElement('use', {
+
+  // IE has issues with the <use> element, place the image inline instead
+  // https://developer.mozilla.org/en-US/docs/Web/SVG/Element/use#Browser_compatibility
+  var arrowElement = goog.userAgent.IE ? 'image' : 'use';
+  var arrowHref = goog.userAgent.IE ? Blockly.FieldDropdown.DROPDOWN_SVG_DATAURI : '#blocklyDropdownArrowSvg';
+
+  this.arrow_ = Blockly.utils.createSvgElement(arrowElement, {
     'height': this.arrowSize_ + 'px',
     'width': this.arrowSize_ + 'px'
   });
   this.arrow_.setAttributeNS('http://www.w3.org/1999/xlink',
-      'xlink:href', '#blocklyDropdownArrow');
+      'xlink:href', arrowHref);
   this.className_ += ' blocklyDropdownText';
 
   Blockly.FieldDropdown.superClass_.init.call(this);

--- a/core/field_dropdown.js
+++ b/core/field_dropdown.js
@@ -130,12 +130,12 @@ Blockly.FieldDropdown.prototype.init = function() {
   this.arrowX_ = 0;
   /** @type {Number} */
   this.arrowY_ = 11;
-  this.arrow_ = Blockly.utils.createSvgElement('image', {
+  this.arrow_ = Blockly.utils.createSvgElement('use', {
     'height': this.arrowSize_ + 'px',
     'width': this.arrowSize_ + 'px'
   });
   this.arrow_.setAttributeNS('http://www.w3.org/1999/xlink',
-      'xlink:href', Blockly.FieldDropdown.DROPDOWN_SVG_DATAURI);
+      'xlink:href', '#blocklyDropdownArrow');
   this.className_ += ' blocklyDropdownText';
 
   Blockly.FieldDropdown.superClass_.init.call(this);

--- a/core/field_string.js
+++ b/core/field_string.js
@@ -94,17 +94,17 @@ Blockly.FieldString.prototype.init = function() {
   this.quoteRightX_ = 0;
   this.quoteY_ = 8;
   if (this.quoteLeft_) this.quoteLeft_.parentNode.removeChild(this.quoteLeft_);
-  this.quoteLeft_ = Blockly.utils.createSvgElement('image', {
+  this.quoteLeft_ = Blockly.utils.createSvgElement('use', {
     'height': this.quoteSize_ + 'px',
     'width': this.quoteSize_ + 'px'
   });
   if (this.quoteRight_) this.quoteRight_.parentNode.removeChild(this.quoteRight_);
-  this.quoteRight_ = Blockly.utils.createSvgElement('image', {
+  this.quoteRight_ = Blockly.utils.createSvgElement('use', {
     'height': this.quoteSize_ + 'px',
     'width': this.quoteSize_ + 'px'
   });
-  var quoteLeft = this.sourceBlock_.RTL ? Blockly.FieldString.QUOTE_1_DATA_URI : Blockly.FieldString.QUOTE_0_DATA_URI;
-  var quoteRight = this.sourceBlock_.RTL ? Blockly.FieldString.QUOTE_0_DATA_URI : Blockly.FieldString.QUOTE_1_DATA_URI;
+  var quoteLeft = this.sourceBlock_.RTL ? '#blocklyStringQuote1' : '#blocklyStringQuote0';
+  var quoteRight = this.sourceBlock_.RTL ? '#blocklyStringQuote0' : '#blocklyStringQuote1';
   this.quoteLeft_.setAttributeNS('http://www.w3.org/1999/xlink',
       'xlink:href', quoteLeft);
   this.quoteRight_.setAttributeNS('http://www.w3.org/1999/xlink',

--- a/core/field_string.js
+++ b/core/field_string.js
@@ -21,6 +21,7 @@ goog.require('goog.math');
 goog.require('goog.dom');
 goog.require('goog.events');
 goog.require('goog.style');
+goog.require('goog.userAgent');
 
 /**
  * Class for an editable text field.
@@ -93,18 +94,29 @@ Blockly.FieldString.prototype.init = function() {
   this.quoteLeftX_ = 0;
   this.quoteRightX_ = 0;
   this.quoteY_ = 8;
+  var quoteElement = goog.userAgent.IE ? 'image' : 'use';
   if (this.quoteLeft_) this.quoteLeft_.parentNode.removeChild(this.quoteLeft_);
-  this.quoteLeft_ = Blockly.utils.createSvgElement('use', {
+  this.quoteLeft_ = Blockly.utils.createSvgElement(quoteElement, {
     'height': this.quoteSize_ + 'px',
     'width': this.quoteSize_ + 'px'
   });
   if (this.quoteRight_) this.quoteRight_.parentNode.removeChild(this.quoteRight_);
-  this.quoteRight_ = Blockly.utils.createSvgElement('use', {
+  this.quoteRight_ = Blockly.utils.createSvgElement(quoteElement, {
     'height': this.quoteSize_ + 'px',
     'width': this.quoteSize_ + 'px'
   });
-  var quoteLeft = this.sourceBlock_.RTL ? '#blocklyStringQuote1' : '#blocklyStringQuote0';
-  var quoteRight = this.sourceBlock_.RTL ? '#blocklyStringQuote0' : '#blocklyStringQuote1';
+  var quoteLeft = this.sourceBlock_.RTL ? '#blocklyStringQuote1Svg' : '#blocklyStringQuote0Svg';
+  var quoteRight = this.sourceBlock_.RTL ? '#blocklyStringQuote0Svg' : '#blocklyStringQuote1Svg';
+  if (goog.userAgent.IE) {
+    // IE has issues with the <use> element, place the image inline instead
+    // https://developer.mozilla.org/en-US/docs/Web/SVG/Element/use#Browser_compatibility
+    quoteLeft = this.sourceBlock_.RTL ?
+      Blockly.FieldString.QUOTE_1_DATA_URI :
+      Blockly.FieldString.QUOTE_0_DATA_URI;
+    quoteRight = this.sourceBlock_.RTL ?
+      Blockly.FieldString.QUOTE_0_DATA_URI :
+      Blockly.FieldString.QUOTE_1_DATA_URI;
+  }
   this.quoteLeft_.setAttributeNS('http://www.w3.org/1999/xlink',
       'xlink:href', quoteLeft);
   this.quoteRight_.setAttributeNS('http://www.w3.org/1999/xlink',

--- a/core/inject.js
+++ b/core/inject.js
@@ -398,6 +398,35 @@ Blockly.createDom_ = function(container, options) {
   Blockly.utils.createSvgElement('path',
       {'d': 'M 0 0 L 10 10 M 10 0 L 0 10', 'stroke': '#cc0'}, disabledPattern);
 
+  // Add dropdown and quote image definitions
+  var arrowSize = 12;
+  var dropdownArrowImage = Blockly.utils.createSvgElement('image',
+      {
+        'id': 'blocklyDropdownArrow',
+        'height': arrowSize + 'px',
+        'width': arrowSize + 'px'
+      }, defs);
+  dropdownArrowImage.setAttributeNS('http://www.w3.org/1999/xlink',
+      'xlink:href', Blockly.FieldDropdown.DROPDOWN_SVG_DATAURI);
+
+  var quoteSize = 12;
+  var leftQuoteImage = Blockly.utils.createSvgElement('image',
+      {
+        'id': 'blocklyStringQuote0',
+        'height': quoteSize + 'px',
+        'width': quoteSize + 'px'
+      }, defs);
+  leftQuoteImage.setAttributeNS('http://www.w3.org/1999/xlink',
+      'xlink:href', Blockly.FieldString.QUOTE_0_DATA_URI);
+  var rightQuoteImage = Blockly.utils.createSvgElement('image',
+      {
+        'id': 'blocklyStringQuote1',
+        'height': quoteSize + 'px',
+        'width': quoteSize + 'px'
+      }, defs);
+  rightQuoteImage.setAttributeNS('http://www.w3.org/1999/xlink',
+      'xlink:href', Blockly.FieldString.QUOTE_1_DATA_URI);
+
   options.stackGlowFilterId = stackGlowFilter.id;
   options.replacementGlowFilterId = replacementGlowFilter.id;
   options.highlightGlowFilterId = highlightGlowFilter.id;

--- a/core/inject.js
+++ b/core/inject.js
@@ -402,7 +402,7 @@ Blockly.createDom_ = function(container, options) {
   var arrowSize = 12;
   var dropdownArrowImage = Blockly.utils.createSvgElement('image',
       {
-        'id': 'blocklyDropdownArrow',
+        'id': 'blocklyDropdownArrowSvg',
         'height': arrowSize + 'px',
         'width': arrowSize + 'px'
       }, defs);
@@ -412,7 +412,7 @@ Blockly.createDom_ = function(container, options) {
   var quoteSize = 12;
   var leftQuoteImage = Blockly.utils.createSvgElement('image',
       {
-        'id': 'blocklyStringQuote0',
+        'id': 'blocklyStringQuote0Svg',
         'height': quoteSize + 'px',
         'width': quoteSize + 'px'
       }, defs);
@@ -420,7 +420,7 @@ Blockly.createDom_ = function(container, options) {
       'xlink:href', Blockly.FieldString.QUOTE_0_DATA_URI);
   var rightQuoteImage = Blockly.utils.createSvgElement('image',
       {
-        'id': 'blocklyStringQuote1',
+        'id': 'blocklyStringQuote1Svg',
         'height': quoteSize + 'px',
         'width': quoteSize + 'px'
       }, defs);


### PR DESCRIPTION
Every dropdown adds a dropdown arrow image, and every string field adds two quote (left/right) images. 
This change makes use of SVG <use> tags to re-use these dropdown assets. 
We inject the images into the SVG initially into <defs> and then reference them from the svg using <use> instead of constantly adding them into the SVG. 

IE has trouble with the feature, so I've guarded it to use the old behaviour.
Feature: https://developer.mozilla.org/en-US/docs/Web/SVG/Element/use#Browser_compatibility