### PR TITLE
Clear content div width when hidden

### DIFF
--- a/core/dropdowndiv.js
+++ b/core/dropdowndiv.js
@@ -151,6 +151,7 @@ Blockly.DropDownDiv.getContentDiv = function() {
  */
 Blockly.DropDownDiv.clearContent = function() {
   Blockly.DropDownDiv.content_.innerHTML = '';
+  Blockly.DropDownDiv.content_.style.width = '';
 };
 
 /**


### PR DESCRIPTION
Some fields forget or don’t set the dropdown content width. Clear it just incase.

Otherwise you end up with something like this if you click on a field with field_slider and then an image_dropdown field:
![screen shot 2018-11-12 at 5 35 15 pm](https://user-images.githubusercontent.com/16690124/48384944-62696e80-e6a1-11e8-809a-e94b0d8cefd3.png)
(Repro on Android)