### PR TITLE
Use default numpad colors when the block has no parent.

### DIFF
--- a/core/field_number.js
+++ b/core/field_number.js
@@ -191,8 +191,11 @@ Blockly.FieldNumber.prototype.showNumPad_ = function() {
   this.addButtons_(contentDiv);
 
   // Set colour and size of drop-down
-  Blockly.DropDownDiv.setColour(this.sourceBlock_.parentBlock_.getColour(),
-      this.sourceBlock_.getColourTertiary());
+  var numPadBackground = this.sourceBlock_.parentBlock_ ?
+    this.sourceBlock_.parentBlock_.getColour() : Blockly.Colours.numPadBackground;
+  var numPadBorder = this.sourceBlock_.parentBlock_ ?
+    this.sourceBlock_.getColourTertiary() : Blockly.Colours.numPadBorder;
+  Blockly.DropDownDiv.setColour(numPadBackground, numPadBorder);
   contentDiv.style.width = Blockly.FieldNumber.DROPDOWN_WIDTH + 'px';
 
   this.position_();
@@ -230,8 +233,10 @@ Blockly.FieldNumber.prototype.position_ = function() {
  * @private
  */
 Blockly.FieldNumber.prototype.addButtons_ = function(contentDiv) {
-  var buttonColour = this.sourceBlock_.parentBlock_.getColour();
-  var buttonBorderColour = this.sourceBlock_.parentBlock_.getColourTertiary();
+  var buttonColour = this.sourceBlock_.parentBlock_ ?
+    this.sourceBlock_.parentBlock_.getColour() : Blockly.Colours.numPadBackground;
+  var buttonBorderColour = this.sourceBlock_.parentBlock_ ?
+    this.sourceBlock_.parentBlock_.getColourTertiary() : this.sourceBlock_.getColourTertiary();
 
   // Add numeric keypad buttons
   var buttons = Blockly.FieldNumber.NUMPAD_BUTTONS;


### PR DESCRIPTION
Recent change (https://github.com/Microsoft/pxt-blockly/pull/156) which was a port of https://github.com/LLK/scratch-blocks/pull/1744 assumes all blocks have a parent. Our math_number block doesn't and that causes a crash. 

This change falls back to the default numPad colors in that case.

@rachel-fenichel FYI