### PR TITLE
Don't show the numpad if the slider is shown

### DIFF
--- a/core/field_number.js
+++ b/core/field_number.js
@@ -163,7 +163,7 @@ Blockly.FieldNumber.prototype.setConstraints_ = function(opt_min, opt_max,
 Blockly.FieldNumber.prototype.showEditor_ = function(e, opt_showNumPad) {
   Blockly.FieldNumber.activeField_ = this;
   // Do not focus on mobile devices so we can show the num-pad
-  var showNumPad = opt_showNumPad ||
+  var showNumPad = (typeof opt_showNumPad !== "undefined") ? opt_showNumPad :
       (goog.userAgent.MOBILE || goog.userAgent.ANDROID || goog.userAgent.IPAD);
   Blockly.FieldNumber.superClass_.showEditor_.call(this, e, false, showNumPad);
 

--- a/core/field_number.js
+++ b/core/field_number.js
@@ -157,13 +157,14 @@ Blockly.FieldNumber.prototype.setConstraints_ = function(opt_min, opt_max,
  * Show the inline free-text editor on top of the text and the num-pad if
  * appropriate.
  * @param {!Event} e A mouse down or touch start event.
+ * @param {boolean=} opt_showNumPad If true, show the num pad.
  * @private
  */
-Blockly.FieldNumber.prototype.showEditor_ = function(e) {
+Blockly.FieldNumber.prototype.showEditor_ = function(e, opt_showNumPad) {
   Blockly.FieldNumber.activeField_ = this;
   // Do not focus on mobile devices so we can show the num-pad
-  var showNumPad =
-      goog.userAgent.MOBILE || goog.userAgent.ANDROID || goog.userAgent.IPAD;
+  var showNumPad = opt_showNumPad ||
+      (goog.userAgent.MOBILE || goog.userAgent.ANDROID || goog.userAgent.IPAD);
   Blockly.FieldNumber.superClass_.showEditor_.call(this, e, false, showNumPad);
 
   // Show a numeric keypad in the drop-down on touch


### PR DESCRIPTION
The slider field calls into the number field and in the case where we're on a touch device, it shows the num pad but then immediately replaces the content with a slider. 
Here: https://github.com/Microsoft/pxt-blockly/blob/develop/core/field_slider.js#L105

Skipping that step as it's unnecessary.