### PR TITLE
Fix clearing the workspace if an edit is being made

### DIFF
--- a/core/field_dropdown.js
+++ b/core/field_dropdown.js
@@ -340,8 +340,10 @@ Blockly.FieldDropdown.prototype.onItemSelected = function(menu, menuItem) {
     this.setValue(value);
 
     // pxtblockly: Fire a UI event that an edit was complete
-    Blockly.Events.fire(new Blockly.Events.Ui(
-        this.sourceBlock_, 'itemSelected', undefined, value));
+    if (this.sourceBlock_.workspace) {
+      Blockly.Events.fire(new Blockly.Events.Ui(
+          this.sourceBlock_, 'itemSelected', undefined, value));
+    }
   }
 };
 

--- a/core/field_textinput.js
+++ b/core/field_textinput.js
@@ -684,8 +684,10 @@ Blockly.FieldTextInput.prototype.maybeSaveEdit_ = function() {
   this.setText(text);
   this.sourceBlock_.rendered && this.sourceBlock_.render();
   // pxtblockly: Fire a UI event that an edit was complete
-  Blockly.Events.fire(new Blockly.Events.Ui(
-      this.sourceBlock_, 'saveEdit', undefined, text));
+  if (this.sourceBlock_.workspace) {
+    Blockly.Events.fire(new Blockly.Events.Ui(
+        this.sourceBlock_, 'saveEdit', undefined, text));
+  }
 };
 
 /**

--- a/tests/playground.html
+++ b/tests/playground.html
@@ -522,6 +522,7 @@ line.blocklyFlyoutLine {
   <p>
     <input type="button" value="Undo" onclick="workspace.undo()" />
     <input type="button" value="Redo" onclick="workspace.undo(true)" />
+    <input type="button" value="Clear" onclick="workspace.clear()" />
   </p>
   
   <p>


### PR DESCRIPTION
A recent change to fix simulator re-runs introduced a bug where we're sending a UI event when a block is disposing. This doesn't affect us today as we don't clear the workspace programmatically, but it affects @guillaumejenkins's work. 