### PR TITLE
Fix function rename to empty

### DIFF
--- a/core/procedures.js
+++ b/core/procedures.js
@@ -161,6 +161,8 @@ Blockly.Procedures.rename = function(name) {
   // Ensure two identically-named procedures don't exist.
   var legalName = Blockly.Procedures.findLegalName(name, this.sourceBlock_);
   var oldName = this.text_;
+  //pxtblockly: ensure no empty procedure name is set
+  if (!legalName) return oldName;
   if (oldName != name && oldName != legalName) {
     // Rename any callers.
     var blocks = this.sourceBlock_.workspace.getAllBlocks();
@@ -170,8 +172,6 @@ Blockly.Procedures.rename = function(name) {
       }
     }
   }
-  //pxtblockly: ensure no empty procedure name is set
-  if (!legalName) return oldName;
   return legalName;
 };
 


### PR DESCRIPTION
If we try to edit the function name to empty. 
Replace it with the previous name.


There's an issue where if you try to edit the function name to empty and there's a call block out there, it becomes out of sync and you can't edit the function name to anything else anymore.