### PR TITLE
Add an option to create a variable from the field_variable dropdown

### DIFF
--- a/blocks/variables_dynamic.js
+++ b/blocks/variables_dynamic.js
@@ -37,7 +37,7 @@ goog.require('Blockly');
 
 /**
  * Unused constant for the common HSV hue for all blocks in this category.
- * @deprecated Use Blockly.Msg.VARIABLES_DYNAMIC_HUE. (2018 April 5)
+ * @deprecated Use Blockly.Msg['VARIABLES_DYNAMIC_HUE']. (2018 April 5)
  */
 Blockly.Constants.VariablesDynamic.HUE = 310;
 
@@ -97,31 +97,53 @@ Blockly.Constants.VariablesDynamic.CUSTOM_CONTEXT_MENU_VARIABLE_GETTER_SETTER_MI
    */
   customContextMenu: function(options) {
     // Getter blocks have the option to create a setter block, and vice versa.
-    if (this.isInFlyout) {
-      return;
-    }
-    var opposite_type;
-    var contextMenuMsg;
-    if (this.type == 'variables_get_dynamic') {
-      opposite_type = 'variables_set_dynamic';
-      contextMenuMsg = Blockly.Msg.VARIABLES_GET_CREATE_SET;
-    } else {
-      opposite_type = 'variables_get_dynamic';
-      contextMenuMsg = Blockly.Msg.VARIABLES_SET_CREATE_GET;
-    }
+    if (!this.isInFlyout) {
+      var opposite_type;
+      var contextMenuMsg;
+      var id = this.getFieldValue('VAR');
+      var variableModel = this.workspace.getVariableById(id);
+      var varType = variableModel.type;
+      if (this.type == 'variables_get_dynamic') {
+        opposite_type = 'variables_set_dynamic';
+        contextMenuMsg = Blockly.Msg['VARIABLES_GET_CREATE_SET'];
+      } else {
+        opposite_type = 'variables_get_dynamic';
+        contextMenuMsg = Blockly.Msg['VARIABLES_SET_CREATE_GET'];
+      }
 
-    var option = {enabled: this.workspace.remainingCapacity() > 0};
-    var name = this.getField('VAR').getText();
-    option.text = contextMenuMsg.replace('%1', name);
-    var xmlField = goog.dom.createDom('field', null, name);
-    xmlField.setAttribute('name', 'VAR');
-    var xmlBlock = goog.dom.createDom('block', null, xmlField);
-    xmlBlock.setAttribute('type', opposite_type);
-    option.callback = Blockly.ContextMenu.callbackFactory(this, xmlBlock);
-    options.push(option);
+      var option = {enabled: this.workspace.remainingCapacity() > 0};
+      var name = this.getField('VAR').getText();
+      option.text = contextMenuMsg.replace('%1', name);
+      var xmlField = document.createElement('field');
+      xmlField.setAttribute('name', 'VAR');
+      xmlField.setAttribute('variabletype', varType);
+      xmlField.appendChild(document.createTextNode(name));
+      var xmlBlock = document.createElement('block');
+      xmlBlock.setAttribute('type', opposite_type);
+      xmlBlock.appendChild(xmlField);
+      option.callback = Blockly.ContextMenu.callbackFactory(this, xmlBlock);
+      options.push(option);
+    } else {
+      if (this.type == 'variables_get_dynamic' ||
+       this.type == 'variables_get_reporter_dynamic') {
+        var renameOption = {
+          text: Blockly.Msg.RENAME_VARIABLE,
+          enabled: true,
+          callback: Blockly.Constants.Variables.RENAME_OPTION_CALLBACK_FACTORY(this)
+        };
+        var name = this.getField('VAR').getText();
+        var deleteOption = {
+          text: Blockly.Msg.DELETE_VARIABLE.replace('%1', name),
+          enabled: true,
+          callback: Blockly.Constants.Variables.DELETE_OPTION_CALLBACK_FACTORY(this)
+        };
+        options.unshift(renameOption);
+        options.unshift(deleteOption);
+      }
+    }
   },
   onchange: function() {
-    var id = this.getField('VAR').getText();
+    var id = this.getFieldValue('VAR');
     var variableModel = this.workspace.getVariableById(id);
     if (this.type == 'variables_get_dynamic') {
       this.outputConnection.setCheck(variableModel.type);
@@ -129,6 +151,35 @@ Blockly.Constants.VariablesDynamic.CUSTOM_CONTEXT_MENU_VARIABLE_GETTER_SETTER_MI
       this.getInput('VALUE').connection.setCheck(variableModel.type);
     }
   }
+};
+
+/**
+  * Callback for rename variable dropdown menu option associated with a
+  * variable getter block.
+  * @param {!Blockly.Block} block The block with the variable to rename.
+  * @return {!function()} A function that renames the variable.
+  */
+Blockly.Constants.VariablesDynamic.RENAME_OPTION_CALLBACK_FACTORY = function(block) {
+  return function() {
+    var workspace = block.workspace;
+    var variable = block.getField('VAR').getVariable();
+    Blockly.Variables.renameVariable(workspace, variable);
+  };
+};
+
+/**
+ * Callback for delete variable dropdown menu option associated with a
+ * variable getter block.
+ * @param {!Blockly.Block} block The block with the variable to delete.
+ * @return {!function()} A function that deletes the variable.
+ */
+Blockly.Constants.VariablesDynamic.DELETE_OPTION_CALLBACK_FACTORY = function(block) {
+  return function() {
+    var workspace = block.workspace;
+    var variable = block.getField('VAR').getVariable();
+    workspace.deleteVariableById(variable.getId());
+    workspace.refreshToolboxSelection();
+  };
 };
 
 Blockly.Extensions.registerMixin('contextMenu_variableDynamicSetterGetter',

--- a/core/constants.js
+++ b/core/constants.js
@@ -289,6 +289,14 @@ Blockly.PROCEDURE_CATEGORY_NAME = 'PROCEDURE';
 
 /**
  * String for use in the dropdown created in field_variable.
+ * This string indicates that this option in the dropdown is 'Create
+ * a variable...' and if selected, should trigger the prompt to create a variable.
+ * @const {string}
+ */
+Blockly.CREATE_VARIABLE_ID = 'CREATE_VARIABLE';
+
+/**
+ * String for use in the dropdown created in field_variable.
  * This string indicates that this option in the dropdown is 'Rename
  * variable...' and if selected, should trigger the prompt to rename a variable.
  * @const {string}

--- a/core/css.js
+++ b/core/css.js
@@ -1046,7 +1046,8 @@ Blockly.Css.CONTENT = [
     'list-style: none;',
     'margin: 0;',
      /* 28px on the left for icon or checkbox; 7em on the right for shortcut. */
-    'padding: 5px 7em 5px 28px;',
+    'min-width: 7em;',
+    'padding: 5px 5px 5px 28px;',
     'white-space: nowrap;',
   '}',
 
@@ -1203,8 +1204,8 @@ Blockly.Css.CONTENT = [
 
   '.blocklyWidgetDiv .goog-menuseparator, ',
   '.blocklyDropDownDiv .goog-menuseparator {',
-    'border-top: 1px solid #ccc;',
-    'margin: 4px 0;',
+    'border-top: 1px solid #ddd;',
+    'margin: 8px;',
     'padding: 0;',
   '}',
 

--- a/core/field_dropdown.js
+++ b/core/field_dropdown.js
@@ -252,6 +252,15 @@ Blockly.FieldDropdown.prototype.showEditor_ = function() {
   var menu = new goog.ui.Menu();
   menu.setRightToLeft(this.sourceBlock_.RTL);
   for (var i = 0; i < options.length; i++) {
+    var separator = options[i] == 'SEPARATOR';
+    if (separator) {
+      // pxtblockly: render separator
+      var menuItem = new goog.ui.MenuSeparator();
+      menuItem.setRightToLeft(this.sourceBlock_.RTL);
+      menu.addChild(menuItem, true);
+      menuItem.getElement().style.borderColor = this.sourceBlock_.getColourTertiary();
+      continue;
+    }
     var content = options[i][0]; // Human-readable text or image.
     var value = options[i][1];   // Language-neutral value.
     if (typeof content == 'object') {

--- a/core/field_dropdown.js
+++ b/core/field_dropdown.js
@@ -252,7 +252,9 @@ Blockly.FieldDropdown.prototype.showEditor_ = function() {
   var menu = new goog.ui.Menu();
   menu.setRightToLeft(this.sourceBlock_.RTL);
   for (var i = 0; i < options.length; i++) {
-    var separator = options[i] == 'SEPARATOR';
+    var content = options[i][0]; // Human-readable text or image.
+    var value = options[i][1];   // Language-neutral value.
+    var separator = value === 'SEPARATOR';
     if (separator) {
       // pxtblockly: render separator
       var menuItem = new goog.ui.MenuSeparator();
@@ -261,8 +263,6 @@ Blockly.FieldDropdown.prototype.showEditor_ = function() {
       menuItem.getElement().style.borderColor = this.sourceBlock_.getColourTertiary();
       continue;
     }
-    var content = options[i][0]; // Human-readable text or image.
-    var value = options[i][1];   // Language-neutral value.
     if (typeof content == 'object') {
       // An image, not text.
       var image = new Image(content['width'], content['height']);

--- a/core/field_variable.js
+++ b/core/field_variable.js
@@ -316,6 +316,8 @@ Blockly.FieldVariable.dropdownCreate = function() {
     // Set the UUID as the internal representation of the variable.
     options[i] = [variableModelList[i].name, variableModelList[i].getId()];
   }
+  options.push('SEPARATOR');
+  options.push([Blockly.Msg.NEW_VARIABLE, 'CREATE_VARIABLE']);
   options.push([Blockly.Msg.RENAME_VARIABLE, Blockly.RENAME_VARIABLE_ID]);
   if (Blockly.Msg.DELETE_VARIABLE) {
     options.push(
@@ -347,6 +349,14 @@ Blockly.FieldVariable.prototype.onItemSelected = function(menu, menuItem) {
     } else if (id == Blockly.DELETE_VARIABLE_ID) {
       // Delete variable.
       workspace.deleteVariableById(this.variable_.getId());
+      return;
+    } else if (id == 'CREATE_VARIABLE') {
+      // Create a variable.
+      var that = this;
+      Blockly.Variables.createVariableButtonHandler(workspace, function(text) {
+        var variable = workspace.getVariable(text);
+        that.setValue(variable.getId());
+      });
       return;
     }
 

--- a/core/field_variable.js
+++ b/core/field_variable.js
@@ -316,8 +316,10 @@ Blockly.FieldVariable.dropdownCreate = function() {
     // Set the UUID as the internal representation of the variable.
     options[i] = [variableModelList[i].name, variableModelList[i].getId()];
   }
-  options.push('SEPARATOR');
-  options.push([Blockly.Msg.NEW_VARIABLE, 'CREATE_VARIABLE']);
+  options.push([undefined, 'SEPARATOR']);
+  if (!this.defaultType_) {
+    options.push([Blockly.Msg.NEW_VARIABLE, Blockly.CREATE_VARIABLE_ID]);
+  }
   options.push([Blockly.Msg.RENAME_VARIABLE, Blockly.RENAME_VARIABLE_ID]);
   if (Blockly.Msg.DELETE_VARIABLE) {
     options.push(
@@ -350,7 +352,7 @@ Blockly.FieldVariable.prototype.onItemSelected = function(menu, menuItem) {
       // Delete variable.
       workspace.deleteVariableById(this.variable_.getId());
       return;
-    } else if (id == 'CREATE_VARIABLE') {
+    } else if (id == Blockly.CREATE_VARIABLE_ID) {
       // Create a variable.
       var that = this;
       Blockly.Variables.createVariableButtonHandler(workspace, function(text) {

--- a/core/field_variable.js
+++ b/core/field_variable.js
@@ -317,9 +317,10 @@ Blockly.FieldVariable.dropdownCreate = function() {
     options[i] = [variableModelList[i].name, variableModelList[i].getId()];
   }
   options.push([undefined, 'SEPARATOR']);
-  if (!this.defaultType_) {
-    options.push([Blockly.Msg.NEW_VARIABLE, Blockly.CREATE_VARIABLE_ID]);
-  }
+  var selectedValueType = workspace.getVariableById(this.getValue()).type;
+  options.push([selectedValueType ?
+    Blockly.Msg.NEW_VARIABLE_TYPE_DROPDOWN.replace('%1', selectedValueType) :
+    Blockly.Msg.NEW_VARIABLE, Blockly.CREATE_VARIABLE_ID]);
   options.push([Blockly.Msg.RENAME_VARIABLE, Blockly.RENAME_VARIABLE_ID]);
   if (Blockly.Msg.DELETE_VARIABLE) {
     options.push(
@@ -355,10 +356,11 @@ Blockly.FieldVariable.prototype.onItemSelected = function(menu, menuItem) {
     } else if (id == Blockly.CREATE_VARIABLE_ID) {
       // Create a variable.
       var that = this;
+      var selectedValueType = workspace.getVariableById(this.getValue()).type;
       Blockly.Variables.createVariableButtonHandler(workspace, function(text) {
-        var variable = workspace.getVariable(text);
+        var variable = workspace.getVariable(text, selectedValueType);
         that.setValue(variable.getId());
-      });
+      }, selectedValueType);
       return;
     }
 

--- a/core/field_variable.js
+++ b/core/field_variable.js
@@ -316,11 +316,13 @@ Blockly.FieldVariable.dropdownCreate = function() {
     // Set the UUID as the internal representation of the variable.
     options[i] = [variableModelList[i].name, variableModelList[i].getId()];
   }
-  options.push([undefined, 'SEPARATOR']);
+  // pxtblockly: add a new variable dropdown option
   var selectedValueType = workspace.getVariableById(this.getValue()).type;
   options.push([selectedValueType ?
     Blockly.Msg.NEW_VARIABLE_TYPE_DROPDOWN.replace('%1', selectedValueType) :
-    Blockly.Msg.NEW_VARIABLE, Blockly.CREATE_VARIABLE_ID]);
+    Blockly.Msg.NEW_VARIABLE_DROPDOWN, Blockly.CREATE_VARIABLE_ID]);
+  // pxtblockly: add a separator
+  options.push([undefined, 'SEPARATOR']);
   options.push([Blockly.Msg.RENAME_VARIABLE, Blockly.RENAME_VARIABLE_ID]);
   if (Blockly.Msg.DELETE_VARIABLE) {
     options.push(

--- a/core/variables.js
+++ b/core/variables.js
@@ -130,9 +130,9 @@ Blockly.Variables.flyoutCategory = function(workspace) {
   var xmlList = [];
   var button = goog.dom.createDom('button');
   button.setAttribute('text', Blockly.Msg.NEW_VARIABLE);
-  button.setAttribute('callbackKey', 'CREATE_VARIABLE');
+  button.setAttribute('callbackKey', Blockly.CREATE_VARIABLE_ID);
 
-  workspace.registerButtonCallback('CREATE_VARIABLE', function(button) {
+  workspace.registerButtonCallback(Blockly.CREATE_VARIABLE_ID, function(button) {
     Blockly.Variables.createVariableButtonHandler(button.getTargetWorkspace());
   });
 

--- a/core/variables_dynamic.js
+++ b/core/variables_dynamic.js
@@ -33,17 +33,20 @@ goog.require('Blockly.constants');
 goog.require('Blockly.VariableModel');
 // TODO Fix circular dependencies
 // goog.require('Blockly.Workspace');
-goog.require('goog.string');
+goog.require('Blockly.Xml');
 
 
 Blockly.VariablesDynamic.onCreateVariableButtonClick_String = function(button) {
-  Blockly.Variables.createVariableButtonHandler(button.getTargetWorkspace(), null, 'String');
+  Blockly.Variables.createVariableButtonHandler(button.getTargetWorkspace(),
+      null, 'String');
 };
 Blockly.VariablesDynamic.onCreateVariableButtonClick_Number = function(button) {
-  Blockly.Variables.createVariableButtonHandler(button.getTargetWorkspace(), null, 'Number');
+  Blockly.Variables.createVariableButtonHandler(button.getTargetWorkspace(),
+      null, 'Number');
 };
 Blockly.VariablesDynamic.onCreateVariableButtonClick_Colour = function(button) {
-  Blockly.Variables.createVariableButtonHandler(button.getTargetWorkspace(), null, 'Colour');
+  Blockly.Variables.createVariableButtonHandler(button.getTargetWorkspace(),
+      null, 'Colour');
 };
 /**
  * Construct the elements (blocks and button) required by the flyout for the
@@ -53,15 +56,16 @@ Blockly.VariablesDynamic.onCreateVariableButtonClick_Colour = function(button) {
  */
 Blockly.VariablesDynamic.flyoutCategory = function(workspace) {
   var xmlList = [];
-  var button = goog.dom.createDom('button');
-  button.setAttribute('text', Blockly.Msg.NEW_STRING_VARIABLE);
+  var button = document.createElement('button');
+  button.setAttribute('text', Blockly.Msg['NEW_STRING_VARIABLE']);
   button.setAttribute('callbackKey', 'CREATE_VARIABLE_STRING');
   xmlList.push(button);
-  button = goog.dom.createDom('button');
-  button.setAttribute('text', Blockly.Msg.NEW_NUMBER_VARIABLE);
+  button = document.createElement('button');
+  button.setAttribute('text', Blockly.Msg['NEW_NUMBER_VARIABLE']);
   button.setAttribute('callbackKey', 'CREATE_VARIABLE_NUMBER');
-  xmlList.push(button);button = goog.dom.createDom('button');
-  button.setAttribute('text', Blockly.Msg.NEW_COLOUR_VARIABLE);
+  xmlList.push(button);
+  button = document.createElement('button');
+  button.setAttribute('text', Blockly.Msg['NEW_COLOUR_VARIABLE']);
   button.setAttribute('callbackKey', 'CREATE_VARIABLE_COLOUR');
   xmlList.push(button);
 

--- a/msg/messages.js
+++ b/msg/messages.js
@@ -131,6 +131,8 @@ Blockly.Msg.NEW_STRING_VARIABLE = 'Create string variable...';
 Blockly.Msg.NEW_NUMBER_VARIABLE = 'Create number variable...';
 /// button text - Text on the button used to launch the variable creation dialogue.
 Blockly.Msg.NEW_COLOUR_VARIABLE = 'Create colour variable...';
+/// dropdown choice - When the user clicks on a variable block, this is one of the dropdown menu choices.  It is used to create a new variable of the same type.
+Blockly.Msg.NEW_VARIABLE_TYPE_DROPDOWN = 'Create a %1 variable...';
 /// prompt - Prompts the user to enter the type for a variable.
 Blockly.Msg.NEW_VARIABLE_TYPE_TITLE = 'New variable type:';
 /// prompt - Prompts the user to enter the name for a new variable.  See [https://github.com/google/blockly/wiki/Variables#dropdown-menu https://github.com/google/blockly/wiki/Variables#dropdown-menu].

--- a/msg/messages.js
+++ b/msg/messages.js
@@ -131,8 +131,10 @@ Blockly.Msg.NEW_STRING_VARIABLE = 'Create string variable...';
 Blockly.Msg.NEW_NUMBER_VARIABLE = 'Create number variable...';
 /// button text - Text on the button used to launch the variable creation dialogue.
 Blockly.Msg.NEW_COLOUR_VARIABLE = 'Create colour variable...';
+/// dropdown choice - When the user clicks on a variable block, this is one of the dropdown menu choices.  It is used to create a new variable with no type.
+Blockly.Msg.NEW_VARIABLE_DROPDOWN = 'New variable...';
 /// dropdown choice - When the user clicks on a variable block, this is one of the dropdown menu choices.  It is used to create a new variable of the same type.
-Blockly.Msg.NEW_VARIABLE_TYPE_DROPDOWN = 'Create a %1 variable...';
+Blockly.Msg.NEW_VARIABLE_TYPE_DROPDOWN = 'New %1 variable...';
 /// prompt - Prompts the user to enter the type for a variable.
 Blockly.Msg.NEW_VARIABLE_TYPE_TITLE = 'New variable type:';
 /// prompt - Prompts the user to enter the name for a new variable.  See [https://github.com/google/blockly/wiki/Variables#dropdown-menu https://github.com/google/blockly/wiki/Variables#dropdown-menu].

--- a/tests/jsunit/field_variable_test.js
+++ b/tests/jsunit/field_variable_test.js
@@ -110,7 +110,8 @@ function test_fieldVariable_dropdownCreateVariablesExist() {
   var result_options = Blockly.FieldVariable.dropdownCreate.call(
       fieldVariable);
 
-  assertEquals(result_options.length, 3);
+  // pxtblockly: add an extra two to the length here to account for CREATE_VARIABLE and the SEPARATOR
+  assertEquals(result_options.length, 5);
   isEqualArrays(result_options[0], ['name1', 'id1']);
   isEqualArrays(result_options[1], ['name2', 'id2']);
 


### PR DESCRIPTION
Also adding a separator to group the variables, and the commands separately. 

<img width="361" alt="screen shot 2018-12-05 at 9 18 10 am" src="https://user-images.githubusercontent.com/16690124/49531412-1a3c0700-f86f-11e8-8c00-29e5c7dd8477.png">

There also seems to be an unnecessary margin to the right of all dropdown fields. The CSS is copied from closure and closure has the concept of a "shortcut" for each MenuItem which isn't used in Blockly. That margin is okay for dropdown's with smaller text. ie: the operator dropdown for the Math operator blocks, but it makes the field_variable dropdown unnecessarily wide, so I've instead reduced the right margin to 5px and set a minimum width on each line to ensure a mid width for things like the Math operator dropdown.

@rachel-fenichel FYI