### PR TITLE
Allow inline function renaming on function definitions

### DIFF
--- a/blocks/pxt_blockly_functions.js
+++ b/blocks/pxt_blockly_functions.js
@@ -185,7 +185,7 @@ Blockly.PXTBlockly.FunctionUtils.updateDisplay_ = function() {
   this.rendered = false;
 
   var connectionMap = this.disconnectOldBlocks_();
-  this.removeAllInputs_();
+  this.removeValueInputs_();
 
   this.createAllInputs_(connectionMap);
   this.deleteShadows_(connectionMap);
@@ -232,23 +232,22 @@ Blockly.PXTBlockly.FunctionUtils.disconnectOldBlocks_ = function() {
 };
 
 /**
- * Removes all inputs on the block, including dummy inputs, except the STACK
- * input. Assumes no input has shadow DOM set.
+ * Removes all value inputs on the block.
  * @private
  * @this Blockly.Block
  */
-Blockly.PXTBlockly.FunctionUtils.removeAllInputs_ = function() {
+Blockly.PXTBlockly.FunctionUtils.removeValueInputs_ = function() {
   // Delete inputs directly instead of with block.removeInput to avoid splicing
   // out of the input list at every index.
-  var stackInput = null;
+  var newInputList = [];
   for (var i = 0, input; input = this.inputList[i]; i++) {
-    if (input.name === 'STACK') {
-      stackInput = input;
-    } else {
+    if (input.type == Blockly.INPUT_VALUE) {
       input.dispose();
+    } else {
+      newInputList.push(input);
     }
   }
-  this.inputList = stackInput ? [stackInput] : [];
+  this.inputList = newInputList;
 };
 
 /**
@@ -260,21 +259,36 @@ Blockly.PXTBlockly.FunctionUtils.removeAllInputs_ = function() {
  * @this Blockly.Block
  */
 Blockly.PXTBlockly.FunctionUtils.createAllInputs_ = function(connectionMap) {
-  // Create the main label.
-  var labelText = '';
-  switch (this.type) {
-    case Blockly.FUNCTION_CALL_BLOCK_TYPE:
-      labelText = Blockly.Msg.FUNCTIONS_CALL_TITLE;
-      break;
-    case Blockly.FUNCTION_DEFINITION_BLOCK_TYPE:
-    case Blockly.FUNCTION_DECLARATION_BLOCK_TYPE:
-      labelText = Blockly.Msg.PROCEDURES_DEFNORETURN_TITLE;
+  var hasTitle = false;
+  var hasName = false;
+  this.inputList.forEach(function(i) {
+    if (i.name == 'function_title') {
+      hasTitle = true;
+    } else if (i.name == 'function_name') {
+      hasName = true;
+    }
+  });
+
+  // Create the main label if it doesn't exist.
+  if (!hasTitle) {
+    var labelText = '';
+    switch (this.type) {
+      case Blockly.FUNCTION_CALL_BLOCK_TYPE:
+        labelText = Blockly.Msg.FUNCTIONS_CALL_TITLE;
+        break;
+      case Blockly.FUNCTION_DEFINITION_BLOCK_TYPE:
+      case Blockly.FUNCTION_DECLARATION_BLOCK_TYPE:
+        labelText = Blockly.Msg.PROCEDURES_DEFNORETURN_TITLE;
+    }
+    this.appendDummyInput('function_title').appendField(labelText, 'function_title');
   }
 
-  this.appendDummyInput().appendField(labelText, 'function_title');
-
-  // Create the function name (overridden by the block type).
-  this.addFunctionLabel_(this.getName());
+  // Create or update the function name (overridden by the block type).
+  if (hasName) {
+    this.updateFunctionLabel_(this.getName());
+  } else {
+    this.addFunctionLabel_(this.getName());
+  }
 
   // Create arguments.
   var self = this;
@@ -324,6 +338,22 @@ Blockly.PXTBlockly.FunctionUtils.deleteShadows_ = function(connectionMap) {
 };
 
 /**
+ * Updates the text of the text input for the function's name.
+ * @param {string} text The new text to set.
+ * @private
+ * @this Blockly.Block
+ */
+Blockly.PXTBlockly.FunctionUtils.updateLabelEditor_ = function(text) {
+  Blockly.Events.disable();
+  this.getField('function_name').setText(text);
+  Blockly.Events.enable();
+}
+
+Blockly.PXTBlockly.FunctionUtils.updateLabelField_ = function(text) {
+  this.getField('function_name').setValue(text);
+}
+
+/**
  * Add a label editor with the given text to a function_declaration
  * block. Editing the text in the label editor updates the text of the
  * corresponding label fields on function calls.
@@ -331,7 +361,14 @@ Blockly.PXTBlockly.FunctionUtils.deleteShadows_ = function(connectionMap) {
  * @private
  */
 Blockly.PXTBlockly.FunctionUtils.addLabelEditor_ = function(text) {
-  this.appendDummyInput('function_name').appendField(new Blockly.FieldTextInput(text || ''), 'function_name');
+  var nameField;
+  if (this.type === Blockly.FUNCTION_DEFINITION_BLOCK_TYPE) {
+    var nameField = new Blockly.FieldTextInput(text || '', Blockly.Functions.rename);
+  } else {
+    var nameField = new Blockly.FieldTextInput(text || '');
+  }
+  nameField.setSpellcheck(false);
+  this.appendDummyInput('function_name').appendField(nameField, 'function_name')
 };
 
 /**
@@ -846,7 +883,7 @@ Blockly.Blocks['function_declaration'] = {
   getName: Blockly.PXTBlockly.FunctionUtils.getName,
   getFunctionId: Blockly.PXTBlockly.FunctionUtils.getFunctionId,
   getArguments: Blockly.PXTBlockly.FunctionUtils.getArguments,
-  removeAllInputs_: Blockly.PXTBlockly.FunctionUtils.removeAllInputs_,
+  removeValueInputs_: Blockly.PXTBlockly.FunctionUtils.removeValueInputs_,
   disconnectOldBlocks_: Blockly.PXTBlockly.FunctionUtils.disconnectOldBlocks_,
   deleteShadows_: Blockly.PXTBlockly.FunctionUtils.deleteShadows_,
   createAllInputs_: Blockly.PXTBlockly.FunctionUtils.createAllInputs_,
@@ -857,6 +894,7 @@ Blockly.Blocks['function_declaration'] = {
   // Exists on all three blocks, but have different implementations.
   populateArgument_: Blockly.PXTBlockly.FunctionUtils.populateArgumentOnDeclaration_,
   addFunctionLabel_: Blockly.PXTBlockly.FunctionUtils.addLabelEditor_,
+  updateFunctionLabel_: Blockly.PXTBlockly.FunctionUtils.updateLabelEditor_,
 
   // Only exists on function_declaration.
   createArgumentEditor_: Blockly.PXTBlockly.FunctionUtils.createArgumentEditor_,
@@ -905,7 +943,7 @@ Blockly.Blocks['function_definition'] = {
   getName: Blockly.PXTBlockly.FunctionUtils.getName,
   getFunctionId: Blockly.PXTBlockly.FunctionUtils.getFunctionId,
   getArguments: Blockly.PXTBlockly.FunctionUtils.getArguments,
-  removeAllInputs_: Blockly.PXTBlockly.FunctionUtils.removeAllInputs_,
+  removeValueInputs_: Blockly.PXTBlockly.FunctionUtils.removeValueInputs_,
   disconnectOldBlocks_: Blockly.PXTBlockly.FunctionUtils.disconnectOldBlocks_,
   deleteShadows_: Blockly.PXTBlockly.FunctionUtils.deleteShadows_,
   createAllInputs_: Blockly.PXTBlockly.FunctionUtils.createAllInputs_,
@@ -915,7 +953,8 @@ Blockly.Blocks['function_definition'] = {
 
   // Exists on all three blocks, but have different implementations.
   populateArgument_: Blockly.PXTBlockly.FunctionUtils.populateArgumentOnDefinition_,
-  addFunctionLabel_: Blockly.PXTBlockly.FunctionUtils.addLabelField_,
+  addFunctionLabel_: Blockly.PXTBlockly.FunctionUtils.addLabelEditor_,
+  updateFunctionLabel_: Blockly.PXTBlockly.FunctionUtils.updateLabelEditor_,
 
   // Only exists on function_definition.
   createArgumentReporter_: Blockly.PXTBlockly.FunctionUtils.createArgumentReporter_
@@ -947,7 +986,7 @@ Blockly.Blocks['function_call'] = {
   getName: Blockly.PXTBlockly.FunctionUtils.getName,
   getFunctionId: Blockly.PXTBlockly.FunctionUtils.getFunctionId,
   getArguments: Blockly.PXTBlockly.FunctionUtils.getArguments,
-  removeAllInputs_: Blockly.PXTBlockly.FunctionUtils.removeAllInputs_,
+  removeValueInputs_: Blockly.PXTBlockly.FunctionUtils.removeValueInputs_,
   disconnectOldBlocks_: Blockly.PXTBlockly.FunctionUtils.disconnectOldBlocks_,
   deleteShadows_: Blockly.PXTBlockly.FunctionUtils.deleteShadows_,
   createAllInputs_: Blockly.PXTBlockly.FunctionUtils.createAllInputs_,
@@ -958,6 +997,7 @@ Blockly.Blocks['function_call'] = {
   // Exists on all three blocks, but have different implementations.
   populateArgument_: Blockly.PXTBlockly.FunctionUtils.populateArgumentOnCaller_,
   addFunctionLabel_: Blockly.PXTBlockly.FunctionUtils.addLabelField_,
+  updateFunctionLabel_: Blockly.PXTBlockly.FunctionUtils.updateLabelField_,
 
   // Only exists on function_call.
   attachShadow_: Blockly.PXTBlockly.FunctionUtils.attachShadow_,


### PR DESCRIPTION
Function names on function definition blocks now use a text input instead of a label, allowing renaming of functions without going into the function editor.

Key changes:
- When rebuilding a function block, preserve all non-value inputs (only recreate arg inputs)
- Use the text input's validator to update a function's name and propagate it to all its callers