### PR TITLE
Delete all variable ids from the flyout

### DIFF
--- a/core/flyout_base.js
+++ b/core/flyout_base.js
@@ -774,6 +774,17 @@ Blockly.Flyout.prototype.placeNewBlock_ = function(oldBlock) {
 
   // Create the new block by cloning the block in the flyout (via XML).
   var xml = Blockly.Xml.blockToDom(oldBlock);
+
+  // pxtblockly: Delete variable ids because they came from the flyout workspace
+  // and not the main workspace
+  var fields = xml.getElementsByTagName("field");
+  if (fields && fields.length) {
+    for (var i = 0; i < fields.length; i++) {
+      var field = fields.item(i);
+      if (field.hasAttribute("id")) field.removeAttribute("id");
+    }
+  }
+
   // The target workspace would normally resize during domToBlock, which will
   // lead to weird jumps.  Save it for terminateDrag.
   targetWorkspace.setResizesEnabled(false);


### PR DESCRIPTION
Fixes https://github.com/Microsoft/pxt-microbit/issues/1759

@guillaumejenkins I think my solution is doing the same thing as the function_call code above it (except for all blocks). I wasn't sure though, so I've left it behind. Let me know if I should remove it.

Here's a postmortem/explanation of this bug, because it's pretty weird:

Our old mutator for the radio blocks in the micro:bit editor adds variable fields to the block based on the parameters to its callback function. When PXT generates the toolbox version of a block using this mutator, we pass it XML looking like this:

```xml
<block type="my_radio_block">
    <mutation … />
</block>
```

The mutation then inflates the block and adds the variable field when the block is rendered.

Now, if we were to re-serialize the block then the XML would look like this:

```xml
<block type="my_radio_block">
    <mutation … />
    <field id="blahblah" type="">varName</field>
</block>
```

(Note the new field for the variable that was created by the mutation)

When you drag a block out of the toolbox, Blockly duplicates the block in the flyout and attaches the copy to the user's cursor. It does that by serializing the block to XML and deserializing it in the editor workspace. So, that means the XML that the editor workspace is getting is the second snippet I shared, not the first. Blockly parses that XML like this:

1. First parse the mutation, which ends up creating a new variable in the workspace with a new id
2. Next parse the field, which attempts to set the field's id to the one referenced in the XML

That means two variables are created with the same name, but different ids (one random id and one from the XML) and Blockly throws an exception.

To remedy that, we can simply delete the variable ids from the XML before we deserialize it (they'll get regenerated in the new workspace).