### PR TITLE
Fade blocks with outputs while dragging

### DIFF
--- a/core/block_drag_surface.js
+++ b/core/block_drag_surface.js
@@ -271,3 +271,12 @@ Blockly.BlockDragSurfaceSvg.prototype.clearAndHide = function(opt_newSurface) {
   var injectionDiv = document.getElementsByClassName('injectionDiv')[0];
   injectionDiv.style.overflow = 'hidden';
 };
+
+/**
+ * Sets the opacity of the drag surface and everything on it.
+ * @param {number} value The new opacity value to use.
+ * @package
+ */
+Blockly.BlockDragSurfaceSvg.prototype.setOpacity = function(value) {
+  this.SVG_.setAttribute('opacity', value);
+};

--- a/core/insertion_marker_manager.js
+++ b/core/insertion_marker_manager.js
@@ -154,6 +154,8 @@ Blockly.InsertionMarkerManager = function(block, handleXY) {
   if (block.outputConnection) {
     var coord = new goog.math.Coordinate(block.outputConnection.x_, block.outputConnection.y_);
     this.handleDXY = goog.math.Coordinate.difference(handleXY, coord);
+    // Fade the dragging block to make targets easier to see.
+    this.workspace_.getBlockDragSurface().setOpacity(0.7);
   }
   else {
     this.handleDXY = new goog.math.Coordinate(0, 0);
@@ -165,6 +167,9 @@ Blockly.InsertionMarkerManager = function(block, handleXY) {
  * @package
  */
 Blockly.InsertionMarkerManager.prototype.dispose = function() {
+  // Unfade the dragging block.
+  this.workspace_.getBlockDragSurface().setOpacity(1);
+
   this.topBlock_ = null;
   this.workspace_ = null;
   this.availableConnections_.length = 0;


### PR DESCRIPTION
Per discussion with @samelhusseini.  You'll want to play with the opacity, I think.

This sets the opacity on the drag surface instead of on the block, so that it applies equally to all child blocks.