### PR TITLE
Fix Input.setVisible return type

### DIFF
--- a/typings/blockly.d.ts
+++ b/typings/blockly.d.ts
@@ -853,7 +853,7 @@ declare namespace Blockly {
         removeField(name: string): void;
         setAlign(align: number): Input;
         setCheck(check: string | string[]): Input;
-        setVisible(visible: boolean): Block;
+        setVisible(visible: boolean): Block[];
     }
 
     class Connection {


### PR DESCRIPTION
We changed this in our pxt typings, but not in our pxt-blockly typings