### PR TITLE
Support semantic-like icons for function args

### DIFF
--- a/core/css.js
+++ b/core/css.js
@@ -1262,7 +1262,7 @@ Blockly.Css.CONTENT = [
     'cursor: pointer;',
   '}',
 
-  '.argumentEditorTypeIcon {',
+  '.functioneditor i.argumentEditorTypeIcon {',
     'position: absolute;',
     'width: 24px;',
     'height: 24px;',

--- a/core/field_argumenteditor.js
+++ b/core/field_argumenteditor.js
@@ -85,11 +85,11 @@ Blockly.FieldArgumentEditor.prototype.showEditor_ = function() {
   div.appendChild(removeButton);
 
   if (this.sourceBlock_ && this.sourceBlock_.typeName_) {
-    var typeIconSvgData =
+    var iconClass =
         Blockly.PXTBlockly.FunctionUtils.getArgumentIcon(this.sourceBlock_.typeName_);
-    if (typeIconSvgData) {
-      var typeIcon = goog.dom.createDom(goog.dom.TagName.IMG, 'argumentEditorTypeIcon');
-      typeIcon.setAttribute('src', typeIconSvgData);
+    if (iconClass) {
+      var className = iconClass + ' icon argumentEditorTypeIcon';
+      var typeIcon = goog.dom.createDom(goog.dom.TagName.I, className);
       div.appendChild(typeIcon);
     }
   }

--- a/core/field_argumenteditor.js
+++ b/core/field_argumenteditor.js
@@ -89,7 +89,8 @@ Blockly.FieldArgumentEditor.prototype.showEditor_ = function() {
         Blockly.PXTBlockly.FunctionUtils.getArgumentIcon(this.sourceBlock_.typeName_);
     if (iconClass) {
       var className = iconClass + ' icon argumentEditorTypeIcon';
-      var typeIcon = goog.dom.createDom(goog.dom.TagName.I, className);
+      var typeIcon = document.createElement('i');
+      typeIcon.className = className;
       div.appendChild(typeIcon);
     }
   }


### PR DESCRIPTION
Changes the arg icon mechanism for the function editor from base-64 encoded SVGs inside an `<img>` element, to `<i>` elements using semantic-style classNames