### PR TITLE
Make all shadow blocks duplicate on drag

### DIFF
--- a/core/pxt_blockly_utils.js
+++ b/core/pxt_blockly_utils.js
@@ -49,12 +49,7 @@ Blockly.pxtBlocklyUtils.measureText = function(fontSize, fontFamily,
  * @package
  */
 Blockly.pxtBlocklyUtils.isShadowArgumentReporter = function(block) {
-  return block.isShadow() &&
-    (block.type === 'variables_get_reporter' ||
-      block.type === 'argument_reporter_boolean' ||
-      block.type === 'argument_reporter_number' ||
-      block.type === 'argument_reporter_string' ||
-      block.type === 'argument_reporter_custom');
+  return block.isShadow()
 };
 
 /**


### PR DESCRIPTION
This PR makes all shadow blocks duplicate when dragged. It's the same behavior that we use for function arguments, but applied to all shadow blocks and not just variables. The motivation for this change is to make refactoring and duplicating code easier in blocks; we've gotten a lot of feedback in MakeCode Arcade that images are especially hard to copy between blocks because it's non-trivial to redraw them in the field editor.
![duplicate_on_drag](https://user-images.githubusercontent.com/13754588/53117892-c56c6c00-3500-11e9-8c38-0441a8656584.gif)

I'm making this a draft pull request because I think this probably requires some discussion before merging.

@rachel-fenichel do you see any issues this creates that I might be overlooking? I'm curious if the Blockly team has considered this approach before.