### PR TITLE
Adding whitelist of blocks to duplicate on drag

### DIFF
--- a/core/pxt_blockly_utils.js
+++ b/core/pxt_blockly_utils.js
@@ -21,6 +21,11 @@ goog.provide('Blockly.pxtBlocklyUtils');
 
 
 /**
+ * Whitelist of blocks whose shadow blocks duplicate on drag
+ */
+Blockly.pxtBlocklyUtils._duplicateOnDragWhitelist = null;
+
+/**
  * Measure some text using a canvas in-memory.
  * Does not exist in Blockly, but needed in scratch-blocks
  * @param {string} fontSize E.g., '10pt'
@@ -54,7 +59,20 @@ Blockly.pxtBlocklyUtils.isShadowArgumentReporter = function(block) {
       block.type === 'argument_reporter_boolean' ||
       block.type === 'argument_reporter_number' ||
       block.type === 'argument_reporter_string' ||
-      block.type === 'argument_reporter_custom');
+      block.type === 'argument_reporter_custom' ||
+      (Blockly.pxtBlocklyUtils._duplicateOnDragWhitelist &&
+        Blockly.pxtBlocklyUtils._duplicateOnDragWhitelist.indexOf(block.type) !== -1));
+};
+
+
+/**
+ * Sets a whitelist of blocks whose shadow blocks duplicate on drag (in addition
+ * to argument reporter blocks).
+ * @param {Array<string>} blockTypes a list of block
+ * @package
+ */
+Blockly.pxtBlocklyUtils.whitelistDraggableBlockTypes = function(blockTypes) {
+  Blockly.pxtBlocklyUtils._duplicateOnDragWhitelist = blockTypes.slice();
 };
 
 /**

--- a/typings/blockly.d.ts
+++ b/typings/blockly.d.ts
@@ -13522,6 +13522,11 @@ declare module Blockly.Functions {
 declare module Blockly.pxtBlocklyUtils {
 
     /**
+     * Whitelist of blocks whose shadow blocks duplicate on drag
+     */
+    var _duplicateOnDragWhitelist: any /*missing*/;
+
+    /**
      * Measure some text using a canvas in-memory.
      * Does not exist in Blockly, but needed in scratch-blocks
      * @param {string} fontSize E.g., '10pt'
@@ -13544,6 +13549,14 @@ declare module Blockly.pxtBlocklyUtils {
      * @package
      */
     function isShadowArgumentReporter(block: Blockly.BlockSvg): boolean;
+
+    /**
+     * Sets a whitelist of blocks whose shadow blocks duplicate on drag (in addition
+     * to argument reporter blocks).
+     * @param {Array<string>} blockTypes a list of block
+     * @package
+     */
+    function whitelistDraggableBlockTypes(blockTypes: string[]): void;
 
     /**
      * Finds and returns an argument reporter of the given name, argument type


### PR DESCRIPTION
Same as https://github.com/Microsoft/pxt-blockly/pull/202, but only for certain blocks. I'll be opening a PR in pxt that consumes this API