### PR TITLE
Small comment fixes to sync with blockly, trim whitespace to fix 'bla…

### DIFF
--- a/core/blockly.js
+++ b/core/blockly.js
@@ -271,8 +271,6 @@ Blockly.copy_ = function(toCopy) {
     var xml = toCopy.toXmlWithXY();
   } else {
     var xml = Blockly.Xml.blockToDom(toCopy);
-    // Copy only the selected block and internal blocks.
-    Blockly.Xml.deleteNext(xml);
     // Encode start position in XML.
     var xy = toCopy.getRelativeToSurfaceXY();
     xml.setAttribute('x', toCopy.RTL ? -xy.x : xy.x);

--- a/core/workspace_comment.js
+++ b/core/workspace_comment.js
@@ -107,7 +107,7 @@ Blockly.WorkspaceComment = function(workspace, content, height, width, opt_id) {
    * @protected
    * @type {!string}
    */
-  this.content_ = content;
+  this.content_ = content.trim(); // PXT Blockly
 
   /**
    * @package
@@ -304,6 +304,7 @@ Blockly.WorkspaceComment.prototype.setEditable = function(editable) {
  * @package
  */
 Blockly.WorkspaceComment.prototype.getContent = function() {
+
   return this.content_;
 };
 
@@ -314,6 +315,7 @@ Blockly.WorkspaceComment.prototype.getContent = function() {
  */
 Blockly.WorkspaceComment.prototype.setContent = function(content) {
   if (this.content_ != content) {
+    content = content.trim(); // PXT Blockly
     Blockly.Events.fire(
         new Blockly.Events.CommentChange(this, this.content_, content));
     this.content_ = content;
@@ -399,10 +401,8 @@ Blockly.WorkspaceComment.fromXml = function(xmlComment, workspace) {
       workspace, info.content, info.h, info.w, info.id);
   comment.data = xmlComment.getAttribute('data');
 
-  var commentX = parseInt(xmlComment.getAttribute('x'), 10);
-  var commentY = parseInt(xmlComment.getAttribute('y'), 10);
-  if (!isNaN(commentX) && !isNaN(commentY)) {
-    comment.moveBy(commentX, commentY);
+  if (!isNaN(info.x) && !isNaN(info.y)) {
+    comment.moveBy(info.x, info.y);
   }
 
   Blockly.WorkspaceComment.fireCreateEvent(comment);

--- a/core/workspace_comment_render_svg.js
+++ b/core/workspace_comment_render_svg.js
@@ -372,7 +372,6 @@ Blockly.WorkspaceCommentSvg.drawDeleteIcon = function(svgGroup) {
  * @private
  */
 Blockly.WorkspaceCommentSvg.prototype.resizeMouseDown_ = function(e) {
-  //this.promote_();
   this.unbindDragEvents_();
   if (Blockly.utils.isRightButton(e)) {
     // No right-click.

--- a/core/workspace_comment_svg.js
+++ b/core/workspace_comment_svg.js
@@ -226,7 +226,6 @@ Blockly.WorkspaceCommentSvg.prototype.unselect = function() {
   Blockly.Events.fire(event);
   Blockly.selected = null;
   this.removeSelect();
-  this.blurFocus();
 };
 
 /**
@@ -319,7 +318,6 @@ Blockly.WorkspaceCommentSvg.prototype.moveBy = function(dx, dy) {
   // TODO: Do I need to look up the relative to surface XY position here?
   var xy = this.getRelativeToSurfaceXY();
   this.translate(xy.x + dx, xy.y + dy);
-  this.xy_ = new goog.math.Coordinate(xy.x + dx, xy.y + dy);
   event.recordNew();
   Blockly.Events.fire(event);
   this.workspace.resizeContents();

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -1081,7 +1081,7 @@ Blockly.WorkspaceSvg.prototype.pasteWorkspaceComment_ = function(xmlComment) {
     Blockly.Events.enable();
   }
   if (Blockly.Events.isEnabled()) {
-    // TODO: Fire a Workspace Comment Create event
+    Blockly.WorkspaceComment.fireCreateEvent(comment);
   }
   comment.select();
 };


### PR DESCRIPTION

…nk' comment

Sync with small fixes from blockly ([PR](https://github.com/LLK/scratch-blocks/commit/91af54d85ab401c037d7c59316a10db58e31ae02#diff-d1710c7d6eca4e11a0cb4ec91b98dfd3)) and fix issue with whitespace increasing while switching editors, from Microsoft/pxt-microbit/issues/1756

![blank-comment](https://user-images.githubusercontent.com/34112083/55645994-e32f2100-578e-11e9-98ac-28ab0e245a63.gif)