### PR TITLE
Added quote padding back

### DIFF
--- a/core/field_string.js
+++ b/core/field_string.js
@@ -61,6 +61,13 @@ Blockly.FieldString.fromJson = function(options) {
 };
 
 /**
+ * Quote padding.
+ * @type {number}
+ * @public
+ */
+Blockly.FieldString.quotePadding = 0;
+
+/**
  * Install this string on a block.
  */
 Blockly.FieldString.prototype.init = function() {


### PR DESCRIPTION
Adds back in the quote padding that was accidentally removed previously

## Before
![image](https://user-images.githubusercontent.com/13285164/55920061-2af9e200-5bad-11e9-88bf-370d96fc6544.png)


## After
![image](https://user-images.githubusercontent.com/13285164/55920020-0bfb5000-5bad-11e9-9b01-d9e1aec25345.png)

@riknoll 