### PR TITLE
Fix crashing on iOS

### DIFF
--- a/core/field_dropdown.js
+++ b/core/field_dropdown.js
@@ -131,10 +131,11 @@ Blockly.FieldDropdown.prototype.init = function() {
   /** @type {Number} */
   this.arrowY_ = 11;
 
-  // IE has issues with the <use> element, place the image inline instead
+  // IE and iOS have issues with the <use> element, place the image inline instead
   // https://developer.mozilla.org/en-US/docs/Web/SVG/Element/use#Browser_compatibility
-  var arrowElement = goog.userAgent.IE ? 'image' : 'use';
-  var arrowHref = goog.userAgent.IE ? Blockly.FieldDropdown.DROPDOWN_SVG_DATAURI : '#blocklyDropdownArrowSvg';
+  var placeImageInline = goog.userAgent.IE || goog.userAgent.IOS;
+  var arrowElement = placeImageInline ? 'image' : 'use';
+  var arrowHref = placeImageInline ? Blockly.FieldDropdown.DROPDOWN_SVG_DATAURI : '#blocklyDropdownArrowSvg';
 
   this.arrow_ = Blockly.utils.createSvgElement(arrowElement, {
     'height': this.arrowSize_ + 'px',


### PR DESCRIPTION
Issue first appeared with https://github.com/Microsoft/pxt-blockly/pull/162. In many cases it's already incidentally been fixed by the change for text input from being svgs to being just text (https://github.com/Microsoft/pxt-blockly/pull/226), but i can still repro it in the simulator semi-regularly with this example from the issue

![](https://user-images.githubusercontent.com/31242877/54749200-bfcf7800-4bcb-11e9-91bb-b3d04fc1fb59.PNG)

~Want to test this on an actual iPad first though~ works both on actual hardware and simulator for me now, for all the examples listed in https://github.com/Microsoft/pxt-microbit/issues/1927.
