### PR TITLE
Added adjustments to bounding box if block has hat

### DIFF
--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -626,7 +626,9 @@ Blockly.BlockSvg.prototype.getBoundingRectangle = function() {
     bottomRight = new goog.math.Coordinate(blockXY.x + blockBounds.width,
         blockXY.y + blockBounds.height);
   }
-
+  if (this.startHat_) {
+    topLeft.y -= Blockly.BlockSvg.START_HAT_HEIGHT;
+  }
   return {topLeft: topLeft, bottomRight: bottomRight};
 };
 


### PR DESCRIPTION
Checks if a block has a hat, if they do adjust the bounding box by bumping the top-left corner to the top of the hat.

Fixes Microsoft/pxt-microbit#1950