### PR TITLE
Use variable name instead of name+id as identifier

### DIFF
--- a/core/xml.js
+++ b/core/xml.js
@@ -783,7 +783,8 @@ Blockly.Xml.domToFieldVariable_ = function(workspace, xml, text, field) {
     type = '';
   }
 
-  var variable = Blockly.Variables.getOrCreateVariablePackage(workspace, xml.id,
+  // pxt-blockly: variable ID and variable name are both unique, only use name
+  var variable = Blockly.Variables.getOrCreateVariablePackage(workspace, null,
       text, type);
 
   // This should never happen :)

--- a/tests/jsunit/event_test.js
+++ b/tests/jsunit/event_test.js
@@ -710,6 +710,7 @@ function test_events_newblock_newvar() {
 
 // The sequence of events should be the same whether the block was created from
 // XML or directly.
+// pxt-blockly: PXT Blockly references variables by name and not ID
 function test_events_newblock_newvar_xml() {
   eventTest_setUpWithMockBlocks();
 
@@ -737,8 +738,8 @@ function test_events_newblock_newvar_xml() {
     assertEquals(event0.group, event1.group);
 
     // Expect the workspace to have a variable with ID 'id1'.
-    assertNotNull(workspace.getVariableById('id1'));
-    assertEquals('id1', event0.varId);
+    assertNotNull(workspace.getVariable('name1'));
+    assertEquals('name1', event0.varName);
   } finally {
     eventTest_tearDownWithMockBlocks();
     Blockly.Events.fire = savedFireFunc;

--- a/tests/jsunit/xml_test.js
+++ b/tests/jsunit/xml_test.js
@@ -222,7 +222,9 @@ function test_domToWorkspace_VariablesAtTop_MissingType() {
   }
 }
 
-function test_domToWorkspace_VariablesAtTop_MismatchBlockType() {
+// pxt-blockly: disabled, since PXT Blockly does not allow variables
+// with duplicate names, irrespective of type
+/* function test_domToWorkspace_VariablesAtTop_MismatchBlockType() {
   // Expect thrown error when the serialized type of a variable does not match
   // the type of a variable field that references it.
   xmlTest_setUpWithMockBlocks();
@@ -243,7 +245,7 @@ function test_domToWorkspace_VariablesAtTop_MismatchBlockType() {
   } finally {
     xmlTest_tearDownWithMockBlocks();
   }
-}
+} */
 
 function test_domToPrettyText() {
   var dom = Blockly.Xml.textToDom(XML_TEXT);


### PR DESCRIPTION
Use variable name instead of name+id as identifier, to avoid conflicts with cached variables (Microsoft/pxt-microbit/issues/1968)