### PR TITLE
Fix block comment color, only duplicate highlighted block

### DIFF
--- a/core/blockly.js
+++ b/core/blockly.js
@@ -271,6 +271,8 @@ Blockly.copy_ = function(toCopy) {
     var xml = toCopy.toXmlWithXY();
   } else {
     var xml = Blockly.Xml.blockToDom(toCopy);
+    // Copy only the selected block and internal blocks.
+    Blockly.Xml.deleteNext(xml);
     // Encode start position in XML.
     var xy = toCopy.getRelativeToSurfaceXY();
     xml.setAttribute('x', toCopy.RTL ? -xy.x : xy.x);

--- a/core/pxt_breakpoint.js
+++ b/core/pxt_breakpoint.js
@@ -149,5 +149,5 @@ Blockly.Breakpoint.prototype.setIconLocation = function(xy) {
 /**
  * Don't do anything, since breakpoint icon doesn't have a bubble.
  */
-Blockly.Icon.prototype.updateColour = function () {
+Blockly.Breakpoint.prototype.updateColour = function () {
 };


### PR DESCRIPTION
Comment color inherits from parent block, don't duplicate entire stack (Microsoft/pxt-arcade/issues/903)