### PR TITLE
Use Scratch line rendering for block comments

### DIFF
--- a/core/bubble.js
+++ b/core/bubble.js
@@ -243,7 +243,7 @@ Blockly.Bubble.prototype.createDom_ = function(content, hasResize) {
   this.bubbleGroup_ = Blockly.utils.createSvgElement('g', {}, null);
   var filter =
       {'filter': 'url(#' + this.workspace_.options.embossFilterId + ')'};
-  if (goog.userAgent.getUserAgentString().indexOf('JavaFX') != -1) {
+  if (goog.userAgent.getUserAgentString().indexOf('JavaFX') != -1 || !this.useArrow_) {
     // Multiple reports that JavaFX can't handle filters.  UserAgent:
     // Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.44
     //     (KHTML, like Gecko) JavaFX/8.0 Safari/537.44
@@ -657,10 +657,15 @@ Blockly.Bubble.prototype.drawLine_ = function() {
  * Change the colour of a bubble.
  * @param {string} hexColour Hex code of colour.
  */
-Blockly.Bubble.prototype.setColour = function(hexColour) {
+Blockly.Bubble.prototype.setColour = function(hexColour, secondaryColour) {
   this.bubbleBack_.setAttribute('fill', hexColour);
   // pxt-blockly: Support line and arrow rendering
-  this.bubbleArrow_.setAttribute(this.useArrow_ ? 'fill' : 'stroke', hexColour);
+  if (this.useArrow_) {
+    this.bubbleArrow_.setAttribute('fill', hexColour);
+  } else {
+    this.bubbleBack_.setAttribute('stroke', secondaryColour);
+    this.bubbleArrow_.setAttribute('stroke', secondaryColour);
+  }
 };
 
 /**

--- a/core/icon.js
+++ b/core/icon.js
@@ -136,7 +136,7 @@ Blockly.Icon.prototype.iconClick_ = function(e) {
  */
 Blockly.Icon.prototype.updateColour = function() {
   if (this.isVisible()) {
-    this.bubble_.setColour(this.block_.getColour());
+    this.bubble_.setColour(this.block_.getColour(), this.block_.getColourSecondary());
   }
 };
 


### PR DESCRIPTION
Use Scratch line rendering for block comments

![scratch-comment](https://user-images.githubusercontent.com/34112083/57094869-5fe9e800-6cc6-11e9-88bb-ecf46a076b5a.gif)

Demo: https://arcade.makecode.com/app/d2852873a7c1df9bc8a9f4a49f288b6a900d2d51-b8f83c898a