### PR TITLE
fix crash when same variable is cached in multiple flyouts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,6 @@ node_js:
 sudo: required
 addons:
   chrome: stable
-  apt:
-    packages:
-    - libgconf-2-4
 cache:
   directories:
   - node_modules

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: node_js
+os: linux
+dist: trusty
 node_js:
 - "8"
 sudo: required

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ node_js:
 sudo: required
 addons:
   chrome: stable
+  apt:
+    packages:
+    - libgconf-2-4
 cache:
   directories:
   - node_modules

--- a/core/variable_map.js
+++ b/core/variable_map.js
@@ -173,12 +173,7 @@ Blockly.VariableMap.prototype.createVariable = function(name,
     opt_type, opt_id) {
   var variable = this.getVariable(name, opt_type);
   if (variable) {
-    if (opt_id && variable.getId() != opt_id) {
-      throw Error('Variable "' + name + '" is already in use and its id is "' +
-                  variable.getId() + '" which conflicts with the passed in ' +
-                  'id, "' + opt_id + '".');
-    }
-    // The variable already exists and has the same ID.
+    // pxt-blockly: no error if the wrong ID is passed, as we do not allow duplicate variable names
     return variable;
   }
   if (opt_id && this.getVariableById(opt_id)) {

--- a/tests/jsunit/variable_map_test.js
+++ b/tests/jsunit/variable_map_test.js
@@ -185,6 +185,7 @@ function test_createVariableIdAlreadyExists() {
   variableMapTest_tearDown();
 }
 
+/** pxt-blockly: cannot have variables with the same name.
 function test_createVariableMismatchedIdAndType() {
   variableMapTest_setUp();
   variable_map.createVariable('name1', 'type1', 'id1');
@@ -202,6 +203,7 @@ function test_createVariableMismatchedIdAndType() {
   }
   variableMapTest_tearDown();
 }
+*/
 
 function test_createVariableTwoSameTypes() {
   variableMapTest_setUp();


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-arcade/issues/980

My understanding is we don't need this crash condition, cause we already only allow a single variable per variable name (versus default blockly which can have multi variables of different types with the same name). I can look into fixing this by invalidating the cached flyouts or something if that approach is preferred, but I don't think this is an an error that really applies to us. Holding off on changing any tests till that's confirmed though.

One other thing: I needed to ``npm link`` blockly from pxt for my changes to apply, not sure if that's intentional (I didn't see it mentioned anywhere in the docs, can add it).