### PR TITLE
Make the string field width narrower for empty string

### DIFF
--- a/core/field_string.js
+++ b/core/field_string.js
@@ -108,12 +108,14 @@ Blockly.FieldString.prototype.initView = function() {
 Blockly.FieldString.prototype.updateSize_ = function() {
   Blockly.FieldString.superClass_.updateSize_.call(this);
 
-  var xPadding = 3;
-  var addedWidth = this.positionLeft(this.size_.width + xPadding);
-  this.textElement_.setAttribute('x', addedWidth);
-  addedWidth += this.positionRight(addedWidth + this.size_.width + xPadding);
+  var sWidth = this.value_ ? this.size_.width : 1;
 
-  this.size_.width += addedWidth;
+  var xPadding = 3;
+  var addedWidth = this.positionLeft(sWidth + xPadding);
+  this.textElement_.setAttribute('x', addedWidth);
+  addedWidth += this.positionRight(addedWidth + sWidth + xPadding);
+
+  this.size_.width = sWidth + addedWidth;
 };
 
 // Position Left


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/1764

<img width="260" alt="Screen Shot 2020-04-08 at 11 42 07 AM" src="https://user-images.githubusercontent.com/13754588/78821332-29b0f000-798e-11ea-9319-70b1647eef4e.png">

top is empty string, bottom is space