### PR TITLE
Update indicator CSS for replacable shadow blocks

### DIFF
--- a/core/renderers/pxt/constants.js
+++ b/core/renderers/pxt/constants.js
@@ -260,7 +260,7 @@ Blockly.pxt.ConstantProvider.prototype.getCSS_ = function(name) {
     selector + ' .blocklyBlockDragSurface > g > .blocklyDraggable > .blocklyConnectionIndicator {',
       'display: block;',
     '}',
-    selector + ' .blocklyDraggable > .blocklyReplaceable > .blocklyConnectionIndicator {',
+    selector + ' .blocklyReplaceable > .blocklyConnectionIndicator {',
       'display: block;',
     '}',
     selector + ' .blocklyConnectionLine {',


### PR DESCRIPTION
Replacable but not draggable, still needs indicator