### PR TITLE
Fix breakpoint click events

### DIFF
--- a/core/pxt_breakpoint.js
+++ b/core/pxt_breakpoint.js
@@ -135,7 +135,7 @@ Blockly.Breakpoint.prototype.setVisible = function(visible) {
  * @return {boolean} True if the breakpoint is Set.
  */
 Blockly.Breakpoint.prototype.isVisible = function() {
-  return !!this.set_ && Blockly.Breakpoint.superClass_.isVisible.call(this);
+  return !!this.set_
 };
 
 /**

--- a/core/pxt_breakpoint.js
+++ b/core/pxt_breakpoint.js
@@ -135,7 +135,7 @@ Blockly.Breakpoint.prototype.setVisible = function(visible) {
  * @return {boolean} True if the breakpoint is Set.
  */
 Blockly.Breakpoint.prototype.isVisible = function() {
-  return !!this.set_
+  return !!this.set_;
 };
 
 /**


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/2848

The super class `isVisible` just checks to see if `this.bubble_` is defined, but breakpoints don't have bubbles.