### PR TITLE
Upgrade travis build env to xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: node_js
 os: linux
-dist: trusty
+dist: xenial
 node_js:
   - 8
-  - 10
 sudo: required
 addons:
   firefox: latest
@@ -11,6 +10,8 @@ addons:
 cache:
   directories:
   - node_modules
+env:
+  - TRAVIS_CI=true
 
 before_install:
   # Symlink closure library used by test/jsunit


### PR DESCRIPTION
Known issue with dpkg in Ubuntu 14.04 (trusty) https://github.com/travis-ci/travis-ci/issues/9361

Probably exposed when we upgraded the chrome version/chromedriver from 77--not really sure why it recently started triggering instead of when we upgraded.