### PR TITLE
Check visibility of widgets before repositioning

### DIFF
--- a/core/dropdowndiv.js
+++ b/core/dropdowndiv.js
@@ -584,6 +584,14 @@ Blockly.DropDownDiv.isVisible = function() {
 };
 
 /**
+ * pxt-blockly Is the container displayed?
+ * @return {boolean} True if container is displayed on screen.
+ */
+Blockly.DropDownDiv.isDisplayed = function() {
+  return Blockly.DropDownDiv.DIV_.style.display != 'none';
+};
+
+/**
  * Hide the menu only if it is owned by the provided object.
  * @param {Object} owner Object which must be owning the drop-down to hide.
  * @param {boolean=} opt_withoutAnimation True if we should hide the dropdown
@@ -725,7 +733,7 @@ Blockly.DropDownDiv.repositionForWindowResize = function() {
   // when a field is focused, the soft keyboard opens triggering a window resize
   // event and we want the dropdown div to stick around so users can type into
   // it.
-  if (Blockly.DropDownDiv.owner_) {
+  if (Blockly.DropDownDiv.isVisible() && Blockly.DropDownDiv.isDisplayed()) {
     var field = /** @type {!Blockly.Field} */ (Blockly.DropDownDiv.owner_);
     var block = Blockly.DropDownDiv.owner_.getSourceBlock();
     var bBox = Blockly.DropDownDiv.positionToField_ ?
@@ -740,6 +748,6 @@ Blockly.DropDownDiv.repositionForWindowResize = function() {
     Blockly.DropDownDiv.positionInternal_(
         primaryX, primaryY, secondaryX, secondaryY);
   } else {
-    Blockly.DropDownDiv.hide();
+    Blockly.DropDownDiv.hideWithoutAnimation();
   }
 };

--- a/core/widgetdiv.js
+++ b/core/widgetdiv.js
@@ -108,7 +108,8 @@ Blockly.WidgetDiv.repositionForWindowResize = function() {
   // when a field is focused, the soft keyboard opens triggering a window resize
   // event and we want the widget div to stick around so users can type into it.
   if (Blockly.WidgetDiv.owner_
-      && Blockly.WidgetDiv.owner_.getScaledBBox) {
+      && Blockly.WidgetDiv.owner_.getScaledBBox
+      && Blockly.WidgetDiv.isDisplayed()) {
     var widgetScaledBBox = Blockly.WidgetDiv.owner_.getScaledBBox();
     Blockly.WidgetDiv.DIV.style.left = widgetScaledBBox.left + 'px';
     Blockly.WidgetDiv.DIV.style.top = widgetScaledBBox.top + 'px';
@@ -150,6 +151,14 @@ Blockly.WidgetDiv.hide = function() {
  */
 Blockly.WidgetDiv.isVisible = function() {
   return !!Blockly.WidgetDiv.owner_;
+};
+
+/**
+ * pxt-blockly Is the container displayed?
+ * @return {boolean} True if container is displayed on screen.
+ */
+Blockly.WidgetDiv.isDisplayed = function() {
+  return Blockly.WidgetDiv.DIV.style.display != 'none';
 };
 
 /**


### PR DESCRIPTION
some of our field editors trigger a re-render in the widget onHide, which causes issues with the repositioning