### PR TITLE
Handle rename in icon class for breakpoints

### DIFF
--- a/core/pxt_breakpoint.js
+++ b/core/pxt_breakpoint.js
@@ -151,3 +151,5 @@ Blockly.Breakpoint.prototype.setIconLocation = function(xy) {
  */
 Blockly.Breakpoint.prototype.updateColour = function () {
 };
+Blockly.Breakpoint.prototype.applyColour = function () {
+};

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -42,6 +42,8 @@ var closureDeps = require('google-closure-deps');
 var packageJson = require('./package.json');
 var argv = require('yargs').argv;
 
+argv.closureLibrary = argv.closureLibrary || argv.cl
+
 const upstream_url = "https://github.com/google/blockly.git";
 
 ////////////////////////////////////////////////////////////


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/3036

Also adds `--cl` as an alias for the very annoying to type `--closure-library` in the gulpfile