### PR TITLE
Round connection difference to account for repositioning in old Edge

### DIFF
--- a/core/rendered_connection.js
+++ b/core/rendered_connection.js
@@ -250,7 +250,7 @@ Blockly.RenderedConnection.prototype.getOffsetInBlock = function() {
 Blockly.RenderedConnection.prototype.tighten = function() {
   var dx = this.targetConnection.x - this.x;
   var dy = this.targetConnection.y - this.y;
-  if (dx != 0 || dy != 0) {
+  if (Math.round(dx) != 0 || Math.round(dy) != 0) {
     var block = this.targetBlock();
     var svgRoot = block.getSvgRoot();
     if (!svgRoot) {


### PR DESCRIPTION
Blockly crash in piano field editor (old Edge) caused by floating point error in connection positions

For https://github.com/microsoft/pxt-microbit/issues/3124