### PR TITLE
Put new functions on center of workspace view instead of at the top

### DIFF
--- a/core/pxt_blockly_functions.js
+++ b/core/pxt_blockly_functions.js
@@ -304,18 +304,16 @@ Blockly.Functions.createFunctionCallbackFactory_ = function(workspace) {
         '</xml>';
       var blockDom = Blockly.Xml.textToDom(blockText);
       Blockly.Events.setGroup(true);
-      var highestBlock = workspace.getTopBlocks(true)[0];
       var block = Blockly.Xml.domToBlock(blockDom.firstChild, workspace);
       block.updateDisplay_();
 
-      if (highestBlock) {
-        var rect = highestBlock.getBoundingRectangle();
-        var highestBlockY = rect.top;
-        var highestBlockX = rect.left;
-        var height = block.getHeightWidth().height;
-        var gap = 20 / workspace.scale;
-        var moveY = highestBlockY - height - gap;
-        block.moveBy(highestBlockX, moveY);
+      if (workspace.getMetrics) {
+        var metrics = workspace.getMetrics();
+        var blockDimensions = block.getHeightWidth();
+        block.moveBy(
+          metrics.viewLeft + (metrics.viewWidth / 2) - (blockDimensions.width / 2),
+          metrics.viewTop + (metrics.viewHeight / 2) - (blockDimensions.height / 2)
+        );
         block.scheduleSnapAndBump();
       }
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/3111

This removes the annoying behavior of always putting function blocks above the "highest" block in the workspace. Now we place it at the center of the current view. One downside to this is that now the function will often be placed on top of other blocks, but it's easy enough to move it.