### PR TITLE
Check height and width instead of function 'rendered' property

### DIFF
--- a/blocks/pxt_blockly_functions.js
+++ b/blocks/pxt_blockly_functions.js
@@ -127,7 +127,8 @@ Blockly.PXTBlockly.FunctionUtils.domToMutation = function(xmlElement) {
   if (idsInUse.indexOf(functionId_) < 0) this.functionId_ = functionId_;
   this.ensureIds_();
 
-  if (this.type !== Blockly.FUNCTION_DEFINITION_BLOCK_TYPE || !this.rendered) {
+  var hw = this.getHeightWidth();
+  if (this.type !== Blockly.FUNCTION_DEFINITION_BLOCK_TYPE || (!hw.height && !hw.width)) {
     this.updateDisplay_();
   } else if (!this.getFieldValue('function_name') && this.name_) {
     // pxt-blockly handle old function case where name was stored in text_


### PR DESCRIPTION
"rendered" is set to false when the block is dirty, we really just want to check if it's visible on the workspace at all.

theoretically related to https://github.com/microsoft/pxt-microbit/issues/3112