### PR TITLE
fix soft keyboard on android

### DIFF
--- a/core/widgetdiv.js
+++ b/core/widgetdiv.js
@@ -131,6 +131,11 @@ Blockly.WidgetDiv.hide = function() {
     Blockly.WidgetDiv.dispose_ && Blockly.WidgetDiv.dispose_();
     Blockly.WidgetDiv.dispose_ = null;
     div.innerHTML = '';
+
+    var ws = Blockly.getMainWorkspace();
+    if (ws) {
+      ws.markFocused();
+    }
   }
   if (Blockly.WidgetDiv.rendererClassName_) {
     Blockly.utils.dom.removeClass(div, Blockly.WidgetDiv.rendererClassName_);
@@ -139,9 +144,6 @@ Blockly.WidgetDiv.hide = function() {
   if (Blockly.WidgetDiv.themeClassName_) {
     Blockly.utils.dom.removeClass(div, Blockly.WidgetDiv.themeClassName_);
     Blockly.WidgetDiv.themeClassName_ = null;
-  }
-  if (Blockly.getMainWorkspace()) {
-    Blockly.getMainWorkspace().markFocused();
   }
 };
 


### PR DESCRIPTION
fix https://github.com/microsoft/pxt-microbit/issues/3061

In https://github.com/google/blockly/pull/3447 this call to `markFocused` was added to keep focus in blockly when widget divs were hidden. Widget divs are hidden on resize so this was stealing focus whenever that happened, and popping the soft keyboard on android triggers a resize causing it to immediately lose focus and hide the keyboard

Worth a note this was happening all across the editor; the resize event is always attached to window, even when we're just using monaco or on the homescreen. It seems like we could probably get away with removing the listener when no workspace is in view?