### PR TITLE
Null check for workspace in UI events

### DIFF
--- a/core/ui_events.js
+++ b/core/ui_events.js
@@ -44,7 +44,7 @@ goog.require('Blockly.utils.object');
 Blockly.Events.Ui = function(block, element, oldValue, newValue) {
   Blockly.Events.Ui.superClass_.constructor.call(this);
   this.blockId = block ? block.id : null;
-  this.workspaceId = block ? block.workspace.id : undefined;
+  this.workspaceId = block && block.workspace ? block.workspace.id : undefined;
   this.element = element;
   this.oldValue = oldValue;
   this.newValue = newValue;


### PR DESCRIPTION
UI events do not require the workspace, add additional null check

For https://github.com/microsoft/pxt-microbit/issues/3181