### PR TITLE
Gulp update to copy typings into node_modules

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1067,7 +1067,7 @@ function pxtPublishTask() {
 
 function pxtPublishTsTask() {
 	if (fs.existsSync('../pxt')) {
-		return gulp.src('./typings/blockly.d.ts').pipe(gulp.dest('../pxt/localtypings/'));
+		return gulp.src('./typings/blockly.d.ts').pipe(gulp.dest('../pxt/node_modules/pxt-blockly/typings/'));
 	}
 }
 


### PR DESCRIPTION
Now that we bundle the typings into the node module we need to update where the publish task copies it as well