### PR TITLE
Add pinch zoom to blockly interface

### DIFF
--- a/typings/parts/blockly-interfaces.d.ts
+++ b/typings/parts/blockly-interfaces.d.ts
@@ -35,6 +35,7 @@ declare module Blockly {
       maxScale?: number;
       minScale?: number;
       scaleSpeed?: number;
+      pinch?: boolean;
     };
     renderer?: string;
     // PXT specific:


### PR DESCRIPTION
fixes microsoft/pxt-microbit#3132

Adding `pinch` to zoom options