### PR TITLE
Save block comment position in XML, use readonly textarea for non-IE

### DIFF
--- a/core/block.js
+++ b/core/block.js
@@ -158,7 +158,8 @@ Blockly.Block = function(workspace, prototypeName, opt_id) {
   this.commentModel = {
     text: null,
     pinned: false,
-    size: new Blockly.utils.Size(160, 80)
+    size: new Blockly.utils.Size(160, 80),
+    xy: new Blockly.utils.Coordinate(10, 10)
   };
 
   /**
@@ -239,7 +240,8 @@ Blockly.Block = function(workspace, prototypeName, opt_id) {
  * @typedef {{
  *            text:?string,
  *            pinned:boolean,
- *            size:Blockly.utils.Size
+ *            size:Blockly.utils.Size,
+ *            xy:Blockly.utils.Coordinate
  *          }}
  */
 Blockly.Block.CommentModel;

--- a/core/comment.js
+++ b/core/comment.js
@@ -173,12 +173,14 @@ Blockly.Comment.prototype.createEditor_ = function() {
 
   this.resizeTextarea_();
 
-  Blockly.bindEventWithChecks_(
-      this.deleteIcon_, 'mousedown', this, this.deleteMouseDown_);
-  Blockly.bindEventWithChecks_(
-      this.deleteIcon_, 'mouseup', this, this.deleteMouseUp_);
-  Blockly.bindEventWithChecks_(
-      this.minimizeArrow_, 'mousedown', this, this.minimizeMouseUp_);
+  if (this.block_.isEditable()) {
+    Blockly.bindEventWithChecks_(
+        this.deleteIcon_, 'mousedown', this, this.deleteMouseDown_);
+    Blockly.bindEventWithChecks_(
+        this.deleteIcon_, 'mouseup', this, this.deleteMouseUp_);
+    Blockly.bindEventWithChecks_(
+        this.minimizeArrow_, 'mousedown', this, this.minimizeMouseUp_);
+  }
 
   return this.svgGroup_;
 };
@@ -226,26 +228,28 @@ Blockly.Comment.prototype.createTextEditor_ = function() {
   // Ideally this would be hooked to the focus event for the comment.
   // However doing so in Firefox swallows the cursor for unknown reasons.
   // So this is hooked to mouseup instead.  No big deal.
-  this.onMouseUpWrapper_ = Blockly.bindEventWithChecks_(
-      textarea, 'mouseup', this, this.startEdit_, true, true);
-  // Don't zoom with mousewheel.
-  this.onWheelWrapper_ = Blockly.bindEventWithChecks_(
-      textarea, 'wheel', this, function(e) {
-        e.stopPropagation();
-      });
-  this.onChangeWrapper_ = Blockly.bindEventWithChecks_(
-      textarea, 'change', this, function(_e) {
-        if (this.cachedText_ != this.model_.text) {
-          Blockly.Events.fire(new Blockly.Events.BlockChange(
-              this.block_, 'comment', null, this.cachedText_, this.model_.text));
-        }
-      });
-  this.onInputWrapper_ = Blockly.bindEventWithChecks_(
-      textarea, 'input', this, function(_e) {
-        this.model_.text = textarea.value;
-      });
+  if (this.block_.isEditable()) {
+    this.onMouseUpWrapper_ = Blockly.bindEventWithChecks_(
+        textarea, 'mouseup', this, this.startEdit_, true, true);
+    // Don't zoom with mousewheel.
+    this.onWheelWrapper_ = Blockly.bindEventWithChecks_(
+        textarea, 'wheel', this, function(e) {
+          e.stopPropagation();
+        });
+    this.onChangeWrapper_ = Blockly.bindEventWithChecks_(
+        textarea, 'change', this, function(_e) {
+          if (this.cachedText_ != this.model_.text) {
+            Blockly.Events.fire(new Blockly.Events.BlockChange(
+                this.block_, 'comment', null, this.cachedText_, this.model_.text));
+          }
+        });
+    this.onInputWrapper_ = Blockly.bindEventWithChecks_(
+        textarea, 'input', this, function(_e) {
+          this.model_.text = textarea.value;
+        });
 
-  setTimeout(textarea.focus.bind(textarea), 0);
+    setTimeout(textarea.focus.bind(textarea), 0);
+  }
 
   return this.foreignObject_;
 };

--- a/core/comment.js
+++ b/core/comment.js
@@ -216,6 +216,10 @@ Blockly.Comment.prototype.createTextEditor_ = function() {
   textarea.setAttribute('dir', this.block_.RTL ? 'RTL' : 'LTR');
   textarea.value = this.model_.text;
 
+  if (!this.block_.isEditable()) {
+    textarea.setAttribute('readonly', true);
+  }
+
   body.appendChild(textarea);
   this.foreignObject_.appendChild(body);
 
@@ -394,16 +398,46 @@ Blockly.Comment.prototype.setVisible = function(visible) {
   if (visible) {
     this.createBubble_();
   } else {
+    this.model_.xy = this.getRelativePosition();
     this.disposeBubble_();
   }
 };
+
+/**
+ * Set the position of the comment relative to the block
+ * @param {Blockly.utils.Coordinate} coord coordinate of position
+ */
+Blockly.Comment.prototype.setRelativePosition = function(coord) {
+  this.model_.xy = coord;
+  if (this.bubble_) {
+    this.bubble_.relativeLeft_ = coord.x;
+    this.bubble_.relativeTop_ = coord.y;
+    this.bubble_.positionBubble_();
+    this.bubble_.renderArrow_();
+  }
+};
+
+/**
+ * Get position of comment relative to block
+ * @return {Blockly.utils.Coordinate} xy coordinate of position
+ */
+Blockly.Comment.prototype.getRelativePosition = function() {
+  if (this.bubble_) {
+    return new Blockly.utils.Coordinate(
+      this.bubble_.relativeLeft_,
+      this.bubble_.relativeTop_);
+  } else {
+    return this.model_.xy;
+  }
+};
+
 
 /**
  * Show the bubble. Handles deciding if it should be editable or not.
  * @private
  */
 Blockly.Comment.prototype.createBubble_ = function() {
-  if (!this.block_.isEditable() || Blockly.utils.userAgent.IE) {
+  if (Blockly.utils.userAgent.IE) {
     // Steal the code from warnings to make an uneditable text bubble.
     // MSIE does not support foreignobject; textareas are impossible.
     // https://docs.microsoft.com/en-us/openspecs/ie_standards/ms-svg/56e6e04c-7c8c-44dd-8100-bd745ee42034
@@ -428,6 +462,7 @@ Blockly.Comment.prototype.createEditableBubble_ = function() {
   this.bubble_.setSvgId(this.block_.id);
   this.bubble_.registerResizeEvent(this.onBubbleResize_.bind(this));
   this.applyColour();
+  this.setRelativePosition(this.model_.xy);
 };
 
 /**

--- a/core/xml.js
+++ b/core/xml.js
@@ -170,6 +170,8 @@ Blockly.Xml.blockToDom = function(block, opt_noId) {
   if (commentText) {
     var size = block.commentModel.size;
     var pinned = block.commentModel.pinned;
+    var position = block.getCommentIcon && block.getCommentIcon()
+      ? block.getCommentIcon().getRelativePosition() : null;
 
     var commentElement = Blockly.utils.xml.createElement('comment');
     commentElement.appendChild(Blockly.utils.xml.createTextNode(commentText));
@@ -177,6 +179,10 @@ Blockly.Xml.blockToDom = function(block, opt_noId) {
       commentElement.setAttribute('pinned', pinned);
       commentElement.setAttribute('h', size.height);
       commentElement.setAttribute('w', size.width);
+      if (position) {
+        commentElement.setAttribute('relx', position.x);
+        commentElement.setAttribute('rely', position.y);
+      }
     }
     element.appendChild(commentElement);
   }
@@ -678,11 +684,17 @@ Blockly.Xml.domToBlockHeadless_ = function(xmlBlock, workspace) {
         var pinned = xmlChildElement.getAttribute('pinned') == 'true';
         var width = parseInt(xmlChildElement.getAttribute('w'), 10);
         var height = parseInt(xmlChildElement.getAttribute('h'), 10);
+        var x = parseInt(xmlChildElement.getAttribute('relx'), 10);
+        var y = parseInt(xmlChildElement.getAttribute('rely'), 10);
+
 
         block.setCommentText(text);
         block.commentModel.pinned = pinned;
         if (!isNaN(width) && !isNaN(height)) {
           block.commentModel.size = new Blockly.utils.Size(width, height);
+        }
+        if (!isNaN(x) && !isNaN(y)) {
+          block.commentModel.xy = new Blockly.utils.Coordinate(x, y);
         }
 
         if (pinned && block.getCommentIcon && !block.isInFlyout) {
@@ -690,6 +702,7 @@ Blockly.Xml.domToBlockHeadless_ = function(xmlBlock, workspace) {
             block.getCommentIcon().setVisible(true);
           }, 1);
         }
+
         break;
       case 'data':
         block.data = xmlChild.textContent;


### PR DESCRIPTION
For https://github.com/microsoft/pxt-arcade/issues/1867