### PR TITLE
Pass extra options object to prompt

### DIFF
--- a/core/blockly.js
+++ b/core/blockly.js
@@ -416,9 +416,10 @@ Blockly.confirm = function(message, callback) {
  * @param {string} message The message to display to the user.
  * @param {string} defaultValue The value to initialize the prompt with.
  * @param {!function(?string)} callback The callback for handling user response.
+ * @param {Object=} options pxt-blockly Additional options for custom prompts.
  */
-Blockly.prompt = function(message, defaultValue, callback) {
-  callback(prompt(message, defaultValue));
+Blockly.prompt = function(message, defaultValue, callback, options) {
+  callback(prompt(message, defaultValue, options));
 };
 
 /**


### PR DESCRIPTION
Mostly updating the typings so we can pass extra options to our dialog (adding placeholder text for https://github.com/microsoft/pxt-arcade/issues/1797)