### PR TITLE
Friendlier argument reporter behavior

### DIFF
--- a/blocks/pxt_blockly_functions.js
+++ b/blocks/pxt_blockly_functions.js
@@ -1210,45 +1210,6 @@ Blockly.PXTBlockly.FunctionUtils.createCustomArgumentReporter = function(typeNam
       'argument_reporter_custom', typeName, ws);
 };
 
-/**
- * Function argument reporters cannot exist outside functions that define them
- * as arguments. Enforce this whenever an event is fired.
- * @param {!Blockly.Events.Abstract} event Change event.
- * @this Blockly.Block
- */
-Blockly.PXTBlockly.FunctionUtils.onReporterChange = function(event) {
-  if (!this.workspace || this.workspace.isFlyout) {
-    // Block is deleted or is in a flyout.
-    return;
-  }
-
-  var thisWasCreated =
-    event.type === Blockly.Events.BLOCK_CREATE && event.ids.indexOf(this.id) != -1;
-  var thisWasDragged =
-    event.type === Blockly.Events.END_DRAG && event.allNestedIds.indexOf(this.id) != -1;
-
-  if (thisWasCreated || thisWasDragged) {
-    var rootBlock = this.getRootBlock();
-    var isTopBlock = Blockly.Functions.isFunctionArgumentReporter(rootBlock);
-
-    if (isTopBlock || rootBlock.previousConnection != null) {
-      // Reporter is by itself on the workspace, or it is slotted into a
-      // stack of statements that is not attached to a function or event. Let
-      // it exist until it is connected to a function or event handler.
-      return;
-    }
-
-    // Ensure an argument with this name and type is defined on the root block.
-    if (!Blockly.pxtBlocklyUtils.hasMatchingArgumentReporter(rootBlock, this)) {
-      // No argument with this name is defined on the root block; delete this
-      // reporter.
-      Blockly.Events.setGroup(event.group);
-      this.dispose();
-      Blockly.Events.setGroup(false);
-    }
-  }
-};
-
 // Argument editor blocks
 
 Blockly.Blocks['argument_editor_boolean'] = {
@@ -1359,7 +1320,6 @@ Blockly.Blocks['argument_reporter_boolean'] = {
     });
     this.typeName_ = 'boolean';
   },
-  onchange: Blockly.PXTBlockly.FunctionUtils.onReporterChange,
   getTypeName: Blockly.PXTBlockly.FunctionUtils.getTypeName
 };
 
@@ -1379,7 +1339,6 @@ Blockly.Blocks['argument_reporter_number'] = {
     });
     this.typeName_ = 'number';
   },
-  onchange: Blockly.PXTBlockly.FunctionUtils.onReporterChange,
   getTypeName: Blockly.PXTBlockly.FunctionUtils.getTypeName
 };
 
@@ -1399,7 +1358,6 @@ Blockly.Blocks['argument_reporter_string'] = {
     });
     this.typeName_ = 'string';
   },
-  onchange: Blockly.PXTBlockly.FunctionUtils.onReporterChange,
   getTypeName: Blockly.PXTBlockly.FunctionUtils.getTypeName
 };
 
@@ -1421,7 +1379,6 @@ Blockly.Blocks['argument_reporter_custom'] = {
     });
     this.typeName_ = '';
   },
-  onchange: Blockly.PXTBlockly.FunctionUtils.onReporterChange,
   getTypeName: Blockly.PXTBlockly.FunctionUtils.getTypeName,
   mutationToDom: Blockly.PXTBlockly.FunctionUtils.argumentMutationToDom,
   domToMutation: Blockly.PXTBlockly.FunctionUtils.argumentDomToMutation

--- a/core/connection.js
+++ b/core/connection.js
@@ -378,8 +378,8 @@ Blockly.Connection.prototype.canConnectToPrevious_ = function(candidate) {
   var isFirstStatementConnection = this == firstStatementConnection;
   var isNextConnection = this == this.sourceBlock_.nextConnection;
 
-  // Can connect to the first statement input of a C-shaped or E-shaped 
-  // block, or to the next connection of any statement block, but not to 
+  // Can connect to the first statement input of a C-shaped or E-shaped
+  // block, or to the next connection of any statement block, but not to
   // the second statement input of an E-shaped block.
   if (isComplexStatement && !isFirstStatementConnection && !isNextConnection) {
     return false;
@@ -462,7 +462,7 @@ Blockly.Connection.prototype.isConnectionAllowed = function(candidate) {
         // Ensure the root block of this stack has an argument reporter
         // matching the name and the type of this reporter.
         var rootBlock = candidate.getSourceBlock().getRootBlock();
-        if (!Blockly.pxtBlocklyUtils.hasMatchingArgumentReporter(rootBlock, this.sourceBlock_)) {
+        if (rootBlock.isEnabled() && !Blockly.pxtBlocklyUtils.hasMatchingArgumentReporter(rootBlock, this.sourceBlock_)) {
           return false;
         }
       }


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-arcade/issues/1900

This PR does two things:

1. Allows argument reporters to be attached to disabled blocks
2. Gets rid of the check that deletes argument reporters when they are dragged to some other location as part of a stack of blocks

Overall it makes refactoring code a lot less confusing and potentially destructive.

Here is the behavior right now:
![2020-06-11 10 32 12](https://user-images.githubusercontent.com/13754588/84420703-486e7580-abcf-11ea-8f42-e16c94745836.gif)


And here it is after the change:
![2020-06-11 10 30 40](https://user-images.githubusercontent.com/13754588/84420737-53c1a100-abcf-11ea-9345-916935c5c641.gif)
