### PR TITLE
Add fromXml override to FieldMultilineInput

### DIFF
--- a/core/field_multilineinput.js
+++ b/core/field_multilineinput.js
@@ -99,11 +99,23 @@ Blockly.FieldMultilineInput.fromJson = function(options) {
  * @package
  */
 Blockly.FieldMultilineInput.prototype.toXml = function(fieldElement) {
-  // Replace '\n' characters with html-escaped equivalent '&#10'. This is needed
-  // so the plain-text representation of the xml produced by `Blockly.Xml.domToText`
-  // will appear on a single line (this is a limitation of the plain-text format).
+  // Replace '\n' characters with html-escaped equivalent '&#10'. This is
+  // needed so the plain-text representation of the xml produced by
+  // `Blockly.Xml.domToText` will appear on a single line (this is a limitation
+  // of the plain-text format).
   fieldElement.textContent = this.getValue().replace(/\n/g, '&#10;');
   return fieldElement;
+};
+
+/**
+ * Sets the field's value based on the given XML element. Should only be
+ * called by Blockly.Xml.
+ * @param {!Element} fieldElement The element containing info about the
+ *    field's state.
+ * @package
+ */
+Blockly.FieldMultilineInput.prototype.fromXml = function(fieldElement) {
+  this.setValue(fieldElement.textContent.replace(/&#10;/g, '\n'));
 };
 
 /**


### PR DESCRIPTION
Missed this in my previous commit. I was testing in playground.html and noticed that I had to decode the content string in the corresponding `fromXml` override.

Related PRs: #315, #316 

Also reformatted comments to wrap at col 80 (as per Blockly's style guide).