### PR TITLE
Don't allow rename to blank string

### DIFF
--- a/core/pxt_blockly_functions.js
+++ b/core/pxt_blockly_functions.js
@@ -500,7 +500,8 @@ Blockly.Functions.rename = function(name) {
   var legalName = Blockly.Functions.findLegalName(name, this.sourceBlock_.workspace, this.sourceBlock_);
   var oldName = this.getValue();
 
-  if (!legalName) return name;
+  if (!name) return oldName;
+  else if (!legalName) return name;
 
   // For newly crecated functions (value not set yet), use legal name and save on block
   if (!oldName) {


### PR DESCRIPTION
The function rename code was updated to support function duplication and missed this case! If the name passed in is an empty string (at some point we were storing the function name on the mutation and not in the function name element), we return the old name.

Fixes https://github.com/microsoft/pxt-arcade/issues/2351