### PR TITLE
Add "Create 'call <function>'" to function context menu.

### DIFF
--- a/blocks/pxt_blockly_functions.js
+++ b/blocks/pxt_blockly_functions.js
@@ -997,7 +997,6 @@ Blockly.Blocks['function_definition'] = {
    */
   init: function() {
     this.jsonInit({
-      "extensions": ["function_contextmenu_edit"],
       "style": {
         "hat": "cap"
       }
@@ -1017,6 +1016,12 @@ Blockly.Blocks['function_definition'] = {
     this.setInputsInline(true);
     this.statementConnection_ = null;
   },
+
+  customContextMenu: function(menuOptions) {
+    menuOptions.push(Blockly.Functions.makeEditOption(this));
+    menuOptions.push(Blockly.Functions.makeCreateCallOption(this));
+  },
+
   // Shared.
   mutationToDom: Blockly.PXTBlockly.FunctionUtils.mutationToDom,
   domToMutation: Blockly.PXTBlockly.FunctionUtils.domToMutation,

--- a/core/pxt_blockly_functions.js
+++ b/core/pxt_blockly_functions.js
@@ -393,6 +393,29 @@ Blockly.Functions.makeEditOption = function(block) {
   return editOption;
 };
 
+/**
+ * Make a context menu option for creating a function call block.
+ * This appears in the context menu for function definitions.
+ * @param {!Blockly.BlockSvg} block The block where the right-click originated.
+ * @return {!Object} A menu option, containing text, enabled, and a callback.
+ * @package
+ */
+Blockly.Functions.makeCreateCallOption = function(block) {
+  var functionName = block.getField("function_name").getText();
+
+  var mutation = goog.dom.createDom('mutation');
+  mutation.setAttribute('name', functionName);
+  var callBlock = goog.dom.createDom('block', null, mutation);
+  callBlock.setAttribute('type', 'function_call');
+
+  var option = {
+    enabled: block.workspace.remainingCapacity() > 0,
+    text: Blockly.Msg.FUNCTIONS_CREATE_CALL_OPTION.replace("%1", functionName),
+    callback: Blockly.ContextMenu.callbackFactory(block, callBlock),
+  };
+  return option;
+}
+
 Blockly.Functions.makeGoToDefinitionOption = function(block) {
   var gtdOption = {
     enabled: true,

--- a/msg/messages.js
+++ b/msg/messages.js
@@ -1637,6 +1637,9 @@ Blockly.Msg.PROCEDURES_IFRETURN_WARNING = 'Warning: This block may be used only 
 /// pxt-blockly: Context menu option to edit functions
 Blockly.Msg.FUNCTIONS_EDIT_OPTION = 'Edit';
 /** @type {string} */
+/// pxt-blockly: Context menu option to create a call block for a function
+Blockly.Msg.FUNCTIONS_CREATE_CALL_OPTION = 'Create \'call %1\'';
+/** @type {string} */
 /// pxt-blockly: Context menu option to go to definition of functions
 Blockly.Msg.FUNCTIONS_GO_TO_DEFINITION_OPTION = 'Go to definition';
 /** @type {string} */


### PR DESCRIPTION
Inspired by @riknoll's awesome microsoft/pxt#7445, I decided to take a crack at microsoft/pxt-arcade#2094. 😊 

I've only tested this in the `tests/playground.html`, but wanted to open the discussion on whether this is useful/desirable/the right place to approach adding this feature. (It seems like a nice to have feature to me!)

No worries if you don't want it or it's not the right approach or anything. Feedback requested @shakao @riknoll. Thanks!

![Kapture 2020-09-03 at 11 20 37](https://user-images.githubusercontent.com/194333/92152478-93b3b100-edd7-11ea-97d1-02ff90ccfb25.gif)

*Edit:* added gif.