### PR TITLE
Enable go to definition for the context menu of function calls

### DIFF
--- a/blocks/extensions.js
+++ b/blocks/extensions.js
@@ -40,6 +40,7 @@ Blockly.PXTBlockly.Extensions.FUNCTION_CONTEXTMENU_EDIT = {
    */
   customContextMenu: function(menuOptions) {
     menuOptions.push(Blockly.Functions.makeEditOption(this));
+    menuOptions.push(Blockly.Functions.makeGoToDefinitionOption(this));
   }
 };
 

--- a/blocks/extensions.js
+++ b/blocks/extensions.js
@@ -39,7 +39,6 @@ Blockly.PXTBlockly.Extensions.FUNCTION_CONTEXTMENU_EDIT = {
    * @this Blockly.Block
    */
   customContextMenu: function(menuOptions) {
-    menuOptions.push(Blockly.Functions.makeEditOption(this));
     menuOptions.push(Blockly.Functions.makeGoToDefinitionOption(this));
   }
 };


### PR DESCRIPTION
Classic "forgetting to call the function" moment.

Fixes https://github.com/microsoft/pxt-arcade/issues/2412