### PR TITLE
select current value when opening the number editor

### DIFF
--- a/core/field_number.js
+++ b/core/field_number.js
@@ -376,6 +376,8 @@ Blockly.FieldNumber.prototype.showNumPad_ = function() {
   contentDiv.style.width = Blockly.FieldNumber.DROPDOWN_WIDTH + 'px';
 
   Blockly.DropDownDiv.showPositionedByField(this, this.onHide_.bind(this));
+
+  this.htmlInput_.select();
 };
 
 /**


### PR DESCRIPTION
re: https://github.com/microsoft/pxt-minecraft/issues/1983, on mobile when we pop up the number picker it doesn't select the current value so if you start putting in a number it will append it to the end. Now it will replace the old number

![replace-old-number-fe](https://user-images.githubusercontent.com/5615930/93809766-89304e80-fc02-11ea-94c9-2741a51f00f7.gif)

There's also a note in that issue that the block gets deleted when you press backspace currently, which is a focus / selection issue that this also resolves