### PR TITLE
propagate readonly mode for FieldNumbers

### DIFF
--- a/core/field_number.js
+++ b/core/field_number.js
@@ -567,8 +567,9 @@ Blockly.FieldNumber.prototype.doClassValidation_ = function(opt_newValue) {
  * @protected
  * @override
  */
-Blockly.FieldNumber.prototype.widgetCreate_ = function() {
-  var htmlInput = Blockly.FieldNumber.superClass_.widgetCreate_.call(this);
+Blockly.FieldNumber.prototype.widgetCreate_ = function(
+    readOnly, withArrow, arrowCallback) {
+  var htmlInput = Blockly.FieldNumber.superClass_.widgetCreate_.call(this, readOnly, withArrow, arrowCallback);
 
   // Set the accessibility state
   if (this.min_ > -Infinity) {


### PR DESCRIPTION
fix https://github.com/microsoft/pxt-minecraft/issues/2008, and any other subclass of numberInput (e.g. if you click on the piano editor on mobile a few times it will pop the keyboard and let you type)

to suppress the virtual keyboard we need to mark inputs as readonly; this is passed as a param to https://github.com/microsoft/pxt-blockly/blob/cf7631c546156200f52b1b3a990c1ff9f38a4c3d/core/field_textinput.js#L388

`FieldNumber` overrides the `widgetCreate_` method and drops those params here when called from `showInlineEditor_` https://github.com/microsoft/pxt-blockly/blob/cf7631c546156200f52b1b3a990c1ff9f38a4c3d/core/field_textinput.js#L423, so we just need to propagate them through. 

Worth a note `field_multilineinput` also overrides this method and drops the parameters; don't really want to change that as we don't use it anyways / make future merges a little easier