### PR TITLE
Show modal for text input with touch

### DIFF
--- a/core/field_textinput.js
+++ b/core/field_textinput.js
@@ -386,14 +386,11 @@ Blockly.FieldTextInput.prototype.showEditor_ = function(_opt_e,
   this.workspace_ = this.sourceBlock_.workspace;
   var quietInput = opt_quietInput || false;
   var readOnly = opt_readOnly || false;
-  var isTouchEvent = undefined;
-  if (_opt_e instanceof PointerEvent) {
-    isTouchEvent = _opt_e.pointerType === "touch";
-  }
+  var isTouchEvent = Blockly.Touch.isTouchEvent(_opt_e);
 
   if (!quietInput && (Blockly.utils.userAgent.MOBILE ||
                       Blockly.utils.userAgent.ANDROID ||
-                      Blockly.utils.userAgent.IPAD||
+                      Blockly.utils.userAgent.IPAD ||
                       isTouchEvent)) {
     this.showPromptEditor_();
   } else {

--- a/core/field_textinput.js
+++ b/core/field_textinput.js
@@ -386,9 +386,15 @@ Blockly.FieldTextInput.prototype.showEditor_ = function(_opt_e,
   this.workspace_ = this.sourceBlock_.workspace;
   var quietInput = opt_quietInput || false;
   var readOnly = opt_readOnly || false;
+  var isTouchEvent = undefined;
+  if (_opt_e instanceof PointerEvent) {
+    isTouchEvent = _opt_e.pointerType === "touch";
+  }
+
   if (!quietInput && (Blockly.utils.userAgent.MOBILE ||
                       Blockly.utils.userAgent.ANDROID ||
-                      Blockly.utils.userAgent.IPAD)) {
+                      Blockly.utils.userAgent.IPAD) ||
+                      isTouchEvent) {
     this.showPromptEditor_();
   } else {
     this.showInlineEditor_(quietInput, readOnly, opt_withArrow, opt_arrowCallback);
@@ -445,7 +451,7 @@ Blockly.FieldTextInput.prototype.showInlineEditor_ = function(
 Blockly.FieldTextInput.prototype.widgetCreate_ = function(
     readOnly, withArrow, arrowCallback) {
   var div = Blockly.WidgetDiv.DIV;
- 
+
   Blockly.utils.dom.addClass(this.getClickTarget_(), 'editing');
 
   var htmlInput = /** @type {HTMLInputElement} */ (document.createElement('input'));

--- a/core/field_textinput.js
+++ b/core/field_textinput.js
@@ -393,8 +393,8 @@ Blockly.FieldTextInput.prototype.showEditor_ = function(_opt_e,
 
   if (!quietInput && (Blockly.utils.userAgent.MOBILE ||
                       Blockly.utils.userAgent.ANDROID ||
-                      Blockly.utils.userAgent.IPAD) ||
-                      isTouchEvent) {
+                      Blockly.utils.userAgent.IPAD||
+                      isTouchEvent)) {
     this.showPromptEditor_();
   } else {
     this.showInlineEditor_(quietInput, readOnly, opt_withArrow, opt_arrowCallback);


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-microbit/issues/3496

The issue was we were first focusing on the workspace, then the text input, and then the workspace again, but instead of looking more into that, I saw that we were using a prompt editor for mobile browsers because of focus and on screen keyboard issues, so I thought making general touch events trigger it would be a good fix. If you guys think it's better to keep it inline then I can do it the other way :D 

(this is what it looks like on my Surface)
![image](https://user-images.githubusercontent.com/18712271/98895430-efe02480-245b-11eb-969e-e75a780d8475.png)
