### PR TITLE
Adding workspace loaded method to fields

### DIFF
--- a/blockly_uncompressed.js
+++ b/blockly_uncompressed.js
@@ -1691,11 +1691,6 @@ goog.addDependency('promise/testsuiteadapter.js', ['goog.promise.testSuiteAdapte
 goog.addDependency('promise/testsuiteadapter.js', ['goog.promise.testSuiteAdapter'], ['goog.Promise'], {});
 goog.addDependency('promise/thenable.js', ['goog.Thenable'], [], {});
 goog.addDependency('promise/thenable.js', ['goog.Thenable'], [], {});
-goog.addDependency('proto/proto.js', ['goog.proto'], ['goog.proto.Serializer'], {});
-goog.addDependency('proto/proto.js', ['goog.proto'], ['goog.proto.Serializer'], {});
-goog.addDependency('proto/serializer.js', ['goog.proto.Serializer'], ['goog.json.Serializer', 'goog.string'], {});
-goog.addDependency('proto/serializer.js', ['goog.proto.Serializer'], ['goog.json.Serializer', 'goog.string'], {});
-goog.addDependency('proto/serializer_test.js', ['goog.protoTest'], ['goog.proto', 'goog.testing.testSuite'], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('proto2/descriptor.js', ['goog.proto2.Descriptor', 'goog.proto2.Metadata'], ['goog.array', 'goog.asserts', 'goog.object', 'goog.string'], {});
 goog.addDependency('proto2/descriptor.js', ['goog.proto2.Descriptor', 'goog.proto2.Metadata'], ['goog.array', 'goog.asserts', 'goog.object', 'goog.string'], {});
 goog.addDependency('proto2/descriptor_test.js', ['goog.proto2.DescriptorTest'], ['goog.proto2.Descriptor', 'goog.proto2.Message', 'goog.testing.testSuite'], {'lang': 'es6', 'module': 'goog'});
@@ -1724,6 +1719,11 @@ goog.addDependency('proto2/textformatserializer.js', ['goog.proto2.TextFormatSer
 goog.addDependency('proto2/textformatserializer_test.js', ['goog.proto2.TextFormatSerializerTest'], ['goog.proto2.ObjectSerializer', 'goog.proto2.TextFormatSerializer', 'goog.testing.testSuite', 'proto2.TestAllTypes'], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('proto2/util.js', ['goog.proto2.Util'], ['goog.asserts'], {});
 goog.addDependency('proto2/util.js', ['goog.proto2.Util'], ['goog.asserts'], {});
+goog.addDependency('proto/proto.js', ['goog.proto'], ['goog.proto.Serializer'], {});
+goog.addDependency('proto/proto.js', ['goog.proto'], ['goog.proto.Serializer'], {});
+goog.addDependency('proto/serializer.js', ['goog.proto.Serializer'], ['goog.json.Serializer', 'goog.string'], {});
+goog.addDependency('proto/serializer.js', ['goog.proto.Serializer'], ['goog.json.Serializer', 'goog.string'], {});
+goog.addDependency('proto/serializer_test.js', ['goog.protoTest'], ['goog.proto', 'goog.testing.testSuite'], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('pubsub/pubsub.js', ['goog.pubsub.PubSub'], ['goog.Disposable', 'goog.array', 'goog.async.run'], {});
 goog.addDependency('pubsub/pubsub.js', ['goog.pubsub.PubSub'], ['goog.Disposable', 'goog.array', 'goog.async.run'], {});
 goog.addDependency('pubsub/pubsub_test.js', ['goog.pubsub.PubSubTest'], ['goog.array', 'goog.pubsub.PubSub', 'goog.testing.MockClock', 'goog.testing.testSuite'], {'lang': 'es6', 'module': 'goog'});

--- a/blockly_uncompressed.js
+++ b/blockly_uncompressed.js
@@ -1691,6 +1691,11 @@ goog.addDependency('promise/testsuiteadapter.js', ['goog.promise.testSuiteAdapte
 goog.addDependency('promise/testsuiteadapter.js', ['goog.promise.testSuiteAdapter'], ['goog.Promise'], {});
 goog.addDependency('promise/thenable.js', ['goog.Thenable'], [], {});
 goog.addDependency('promise/thenable.js', ['goog.Thenable'], [], {});
+goog.addDependency('proto/proto.js', ['goog.proto'], ['goog.proto.Serializer'], {});
+goog.addDependency('proto/proto.js', ['goog.proto'], ['goog.proto.Serializer'], {});
+goog.addDependency('proto/serializer.js', ['goog.proto.Serializer'], ['goog.json.Serializer', 'goog.string'], {});
+goog.addDependency('proto/serializer.js', ['goog.proto.Serializer'], ['goog.json.Serializer', 'goog.string'], {});
+goog.addDependency('proto/serializer_test.js', ['goog.protoTest'], ['goog.proto', 'goog.testing.testSuite'], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('proto2/descriptor.js', ['goog.proto2.Descriptor', 'goog.proto2.Metadata'], ['goog.array', 'goog.asserts', 'goog.object', 'goog.string'], {});
 goog.addDependency('proto2/descriptor.js', ['goog.proto2.Descriptor', 'goog.proto2.Metadata'], ['goog.array', 'goog.asserts', 'goog.object', 'goog.string'], {});
 goog.addDependency('proto2/descriptor_test.js', ['goog.proto2.DescriptorTest'], ['goog.proto2.Descriptor', 'goog.proto2.Message', 'goog.testing.testSuite'], {'lang': 'es6', 'module': 'goog'});
@@ -1719,11 +1724,6 @@ goog.addDependency('proto2/textformatserializer.js', ['goog.proto2.TextFormatSer
 goog.addDependency('proto2/textformatserializer_test.js', ['goog.proto2.TextFormatSerializerTest'], ['goog.proto2.ObjectSerializer', 'goog.proto2.TextFormatSerializer', 'goog.testing.testSuite', 'proto2.TestAllTypes'], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('proto2/util.js', ['goog.proto2.Util'], ['goog.asserts'], {});
 goog.addDependency('proto2/util.js', ['goog.proto2.Util'], ['goog.asserts'], {});
-goog.addDependency('proto/proto.js', ['goog.proto'], ['goog.proto.Serializer'], {});
-goog.addDependency('proto/proto.js', ['goog.proto'], ['goog.proto.Serializer'], {});
-goog.addDependency('proto/serializer.js', ['goog.proto.Serializer'], ['goog.json.Serializer', 'goog.string'], {});
-goog.addDependency('proto/serializer.js', ['goog.proto.Serializer'], ['goog.json.Serializer', 'goog.string'], {});
-goog.addDependency('proto/serializer_test.js', ['goog.protoTest'], ['goog.proto', 'goog.testing.testSuite'], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('pubsub/pubsub.js', ['goog.pubsub.PubSub'], ['goog.Disposable', 'goog.array', 'goog.async.run'], {});
 goog.addDependency('pubsub/pubsub.js', ['goog.pubsub.PubSub'], ['goog.Disposable', 'goog.array', 'goog.async.run'], {});
 goog.addDependency('pubsub/pubsub_test.js', ['goog.pubsub.PubSubTest'], ['goog.array', 'goog.pubsub.PubSub', 'goog.testing.MockClock', 'goog.testing.testSuite'], {'lang': 'es6', 'module': 'goog'});

--- a/core/block.js
+++ b/core/block.js
@@ -1918,7 +1918,7 @@ Blockly.Block.prototype.enableBreakpoint = function(enable) {
 }
 
 /**
- * Returns a boolean representing if the block has a breakpoint set or not 
+ * Returns a boolean representing if the block has a breakpoint set or not
  * (regardless of whether it is enabled).
  * @return {boolean} Block's breakpoint set or not.
  */
@@ -2072,4 +2072,20 @@ Blockly.Block.prototype.toDevString = function() {
     msg += ' (id="' + this.id + '")';
   }
   return msg;
+};
+
+
+/**
+ * pxtblockly: this function notifies all fields that they are loaded in the
+ * workspace. used in pxt for fields that need to upgrade legacy values so that
+ * they know when it's safe to perform the upgrade
+ */
+Blockly.Block.prototype.onLoadedIntoWorkspace = function() {
+  for (var i = 0, input; (input = this.inputList[i]); i++) {
+    for (var j = 0, field; (field = input.fieldRow[j]); j++) {
+      if (field.onLoadedIntoWorkspace) {
+        field.onLoadedIntoWorkspace();
+      }
+    }
+  }
 };

--- a/core/field.js
+++ b/core/field.js
@@ -337,6 +337,14 @@ Blockly.Field.prototype.initModel = function() {
 };
 
 /**
+ * pxtblockly: used by subclasses to perform upgrades from legacy values into
+ * new. No-op by default.
+ * @package
+ */
+Blockly.Field.prototype.onLoadedIntoWorkspace = function() {
+};
+
+/**
  * Create a field border rect element. Not to be overridden by subclasses.
  * Instead modify the result of the function inside initView, or create a
  * separate function to call.

--- a/core/workspace.js
+++ b/core/workspace.js
@@ -48,6 +48,11 @@ Blockly.Workspace = function(opt_options) {
   /** @type {number} */
   this.toolboxPosition = this.options.toolboxPosition;
 
+  // pxtblockly: used to prevent workspace load notifcations from happening while
+  // workspace is still being loaded from xml
+  /** @type {boolean} */
+  this.loadingEventsDisabled = false;
+
   /**
    * @type {!Array.<!Blockly.Block>}
    * @private
@@ -558,7 +563,12 @@ Blockly.Workspace.prototype.getWidth = function() {
  * @return {!Blockly.Block} The created block.
  */
 Blockly.Workspace.prototype.newBlock = function(prototypeName, opt_id) {
-  return new Blockly.Block(this, prototypeName, opt_id);
+  var block = new Blockly.Block(this, prototypeName, opt_id);
+  // pxtblockly
+  if (!this.loadingEventsDisabled) {
+    block.onLoadedIntoWorkspace();
+  }
+  return block;
 };
 
 /**

--- a/core/workspace.js
+++ b/core/workspace.js
@@ -48,7 +48,7 @@ Blockly.Workspace = function(opt_options) {
   /** @type {number} */
   this.toolboxPosition = this.options.toolboxPosition;
 
-  // pxtblockly: used to prevent workspace load notifcations from happening while
+  // pxtblockly: used to prevent workspace load notifications from happening while
   // workspace is still being loaded from xml
   /** @type {boolean} */
   this.loadingEventsDisabled = false;

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -870,7 +870,12 @@ Blockly.WorkspaceSvg.prototype.dispose = function() {
  * @override
  */
 Blockly.WorkspaceSvg.prototype.newBlock = function(prototypeName, opt_id) {
-  return new Blockly.BlockSvg(this, prototypeName, opt_id);
+  var block = new Blockly.BlockSvg(this, prototypeName, opt_id);
+  // pxtblockly
+  if (!this.loadingEventsDisabled) {
+    block.onLoadedIntoWorkspace();
+  }
+  return block;
 };
 
 /**

--- a/core/xml.js
+++ b/core/xml.js
@@ -392,6 +392,9 @@ Blockly.Xml.domToWorkspace = function(xml, workspace) {
                  'swap the arguments.');
   }
 
+  // pxtblockly
+  workspace.loadingEventsDisabled = true;
+
   var width;  // Not used in LTR.
   if (workspace.RTL) {
     width = workspace.getWidth();
@@ -467,6 +470,13 @@ Blockly.Xml.domToWorkspace = function(xml, workspace) {
   if (workspace.setResizesEnabled) {
     workspace.setResizesEnabled(true);
   }
+
+  // pxtblockly
+  workspace.loadingEventsDisabled = false;
+  workspace.getAllBlocks(false).forEach(function (block) {
+    block.onLoadedIntoWorkspace();
+  });
+
   Blockly.Events.fire(new Blockly.Events.FinishedLoading(workspace));
   return newBlockIds;
 };

--- a/tests/scripts/selenium-config.js
+++ b/tests/scripts/selenium-config.js
@@ -9,7 +9,7 @@ module.exports = {
     chrome: {
       // check for more recent versions of chrome driver here:
       // https://chromedriver.storage.googleapis.com/index.html
-      version: '85.0.4183.87',
+      version: '87.0.4280.20',
       arch: process.arch,
       baseURL: 'https://chromedriver.storage.googleapis.com'
     },


### PR DESCRIPTION
This adds an "onWorkspaceLoaded" method for fields that has the following semantics:

1. If the workspace is being loaded from XML, this will fire for all fields after all blocks are initialized
2. If the workspace is already loaded, this will fire after all fields in the block have been initialized

The reasoning for this is that it's pretty difficult right now to know when a field has received the "real" value while it's being created.

When Blockly creates blocks (e.g. when loading a workspace from XML), it often calls setValue multiple times with different values. This causes a lot of problems in the field editors in PXT that are tied to resources outside of the Blockly workspace. For example, we have image editors for which the source of truth is a file in the user's project. We need to know when we have the real value so that we can be sure it's safe to change those files based on the value in the field editor.