### PR TITLE
Check pointer events to see if they are triggered by a mouse

### DIFF
--- a/core/touch.js
+++ b/core/touch.js
@@ -234,6 +234,10 @@ Blockly.Touch.isMouseOrTouchEvent = function(e) {
  * @return {boolean} True if it is a touch event; false otherwise.
  */
 Blockly.Touch.isTouchEvent = function(e) {
+  if (e instanceof PointerEvent) {
+      if (e.pointerType == "mouse")
+          return false;
+  }
   return Blockly.utils.string.startsWith(e.type, 'touch') ||
       Blockly.utils.string.startsWith(e.type, 'pointer');
 };


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-microbit/issues/3496

The way Blockly was detecting touch events (by seeing if it was a PointerEvent or a TouchEvent and not a MouseEvent) doesn't work anymore since Chrome will send PointerEvents always. 

This change will see what is the source of the PointerEvent (mouse, pen, or touch) to decide if it is a touch event or not