### PR TITLE
Check pointer events to see if they are triggered by a mouse 

### DIFF
--- a/core/field_textinput.js
+++ b/core/field_textinput.js
@@ -386,7 +386,9 @@ Blockly.FieldTextInput.prototype.showEditor_ = function(_opt_e,
   this.workspace_ = this.sourceBlock_.workspace;
   var quietInput = opt_quietInput || false;
   var readOnly = opt_readOnly || false;
-  var isTouchEvent = Blockly.Touch.isTouchEvent(_opt_e);
+  var isTouchEvent = false;
+  if (_opt_e)
+    isTouchEvent = Blockly.Touch.isTouchEvent(_opt_e);
 
   if (!quietInput && (Blockly.utils.userAgent.MOBILE ||
                       Blockly.utils.userAgent.ANDROID ||

--- a/core/touch.js
+++ b/core/touch.js
@@ -235,7 +235,7 @@ Blockly.Touch.isMouseOrTouchEvent = function(e) {
  */
 Blockly.Touch.isTouchEvent = function(e) {
   if (e instanceof PointerEvent) {
-      if (e.pointerType == "mouse")
+      if (e.pointerType && e.pointerType == "mouse")
           return false;
   }
   return Blockly.utils.string.startsWith(e.type, 'touch') ||

--- a/core/touch.js
+++ b/core/touch.js
@@ -234,6 +234,10 @@ Blockly.Touch.isMouseOrTouchEvent = function(e) {
  * @return {boolean} True if it is a touch event; false otherwise.
  */
 Blockly.Touch.isTouchEvent = function(e) {
+  if (e instanceof PointerEvent) {
+      if (e.pointerType == "mouse")
+          return false;
+  }
   return Blockly.utils.string.startsWith(e.type, 'touch') ||
       Blockly.utils.string.startsWith(e.type, 'pointer');
 };

--- a/core/touch.js
+++ b/core/touch.js
@@ -234,10 +234,10 @@ Blockly.Touch.isMouseOrTouchEvent = function(e) {
  * @return {boolean} True if it is a touch event; false otherwise.
  */
 Blockly.Touch.isTouchEvent = function(e) {
-  if (e instanceof PointerEvent) {
-      if (e.pointerType && e.pointerType == "mouse")
-          return false;
+  if (e instanceof PointerEvent && e.pointerType == "mouse") {
+    return false;
   }
+
   return Blockly.utils.string.startsWith(e.type, 'touch') ||
       Blockly.utils.string.startsWith(e.type, 'pointer');
 };


### PR DESCRIPTION
fixes microsoft/pxt-microbit#3496

The way Blockly was detecting touch events (by seeing if it was a PointerEvent or a TouchEvent and not a MouseEvent) doesn't work anymore since Chrome will send PointerEvents always.

This change will see what is the source of the PointerEvent (mouse, pen, or touch) to decide if it is a touch event or not