### PR TITLE
Disable workspace loading events for insertion marker blocks

### DIFF
--- a/core/insertion_marker_manager.js
+++ b/core/insertion_marker_manager.js
@@ -263,7 +263,9 @@ Blockly.InsertionMarkerManager.prototype.createMarkerBlock_ = function(sourceBlo
 
   Blockly.Events.disable();
   try {
+    this.workspace_.loadingEventsDisabled = true;
     var result = this.workspace_.newBlock(imType);
+    this.workspace_.loadingEventsDisabled = false;
     result.setInsertionMarker(true);
     if (sourceBlock.mutationToDom) {
       var oldMutationDom = sourceBlock.mutationToDom();


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-arcade/issues/2814

the workspace loaded handler for the tilemap insertion marker was creating an extra empty tilemap