### PR TITLE
Don't focus on workspace every time blockly is resized

### DIFF
--- a/core/blockly.js
+++ b/core/blockly.js
@@ -355,9 +355,12 @@ Blockly.hideChaffOnResize = function(opt_allowToolbox) {
  * @private
  */
 Blockly.hideChaffInternal_ = function(opt_allowToolbox) {
-  Blockly.Tooltip.hide();
-  Blockly.WidgetDiv.hide();
-  Blockly.DropDownDiv.hideWithoutAnimation();
+  if (!Blockly.utils.isOnScreenKeyboardResize()) {
+    // If the onscreen keyboard isn't the source of the resize, hide everything
+    Blockly.Tooltip.hide();
+    Blockly.WidgetDiv.hide();
+    Blockly.DropDownDiv.hideWithoutAnimation();
+  }
   if (!opt_allowToolbox) {
     var workspace = Blockly.getMainWorkspace();
     // For now the trashcan flyout always autocloses because it overlays the

--- a/core/blockly.js
+++ b/core/blockly.js
@@ -356,7 +356,6 @@ Blockly.hideChaffOnResize = function(opt_allowToolbox) {
  */
 Blockly.hideChaffInternal_ = function(opt_allowToolbox) {
   if (!Blockly.utils.isOnScreenKeyboardResize()) {
-    // If the onscreen keyboard isn't the source of the resize, hide everything
     Blockly.Tooltip.hide();
     Blockly.WidgetDiv.hide();
     Blockly.DropDownDiv.hideWithoutAnimation();

--- a/core/field_textinput.js
+++ b/core/field_textinput.js
@@ -386,14 +386,10 @@ Blockly.FieldTextInput.prototype.showEditor_ = function(_opt_e,
   this.workspace_ = this.sourceBlock_.workspace;
   var quietInput = opt_quietInput || false;
   var readOnly = opt_readOnly || false;
-  var isTouchEvent = false;
-  if (_opt_e)
-    isTouchEvent = Blockly.Touch.isTouchEvent(_opt_e);
 
   if (!quietInput && (Blockly.utils.userAgent.MOBILE ||
                       Blockly.utils.userAgent.ANDROID ||
-                      Blockly.utils.userAgent.IPAD ||
-                      isTouchEvent)) {
+                      Blockly.utils.userAgent.IPAD)) {
     this.showPromptEditor_();
   } else {
     this.showInlineEditor_(quietInput, readOnly, opt_withArrow, opt_arrowCallback);

--- a/core/inject.js
+++ b/core/inject.js
@@ -371,6 +371,7 @@ Blockly.init_ = function(mainWorkspace) {
   var workspaceResizeHandler = Blockly.bindEventWithChecks_(window, 'resize',
       null,
       function() {
+        Blockly.utils.resizeTracker(mainWorkspace);
         Blockly.hideChaffOnResize(true);
         Blockly.svgResize(mainWorkspace);
       });

--- a/core/utils.js
+++ b/core/utils.js
@@ -587,6 +587,47 @@ Blockly.utils.getBlockTypeCounts = function(block, opt_stripFollowing) {
   return typeCountsMap;
 };
 
+var resizeFromKeyboard = true;
+var initialWidth = 0;
+var debounceTimeout = null;
+
+/**
+ * Called in the resize event handler to sense if the source
+ * is from an on screen keyboard or user.
+ * @param {!Blockly.WorkspaceSvg} workspace Any workspace in the SVG.
+ */
+Blockly.utils.resizeTracker = function(workspace) {
+  if (debounceTimeout) {
+    clearTimeout(debounceTimeout);
+  }
+  debounceTimeout = setTimeout(function(){
+    resizeFromKeyboard = true;
+    initialWidth = workspace.width;
+  }, 1000);
+
+  if (resizeFromKeyboard) {
+    // If the on-screen keyboard is causing the resize, only the
+    // height will change.
+    if (workspace.width != initialWidth) {
+      resizeFromKeyboard = false;
+    }
+  }
+}
+
+/**
+ * Use during resize to see if the source of the resize
+ * is from an on-screen keyboard appearing.
+ */
+Blockly.utils.isOnScreenKeyboardResize = function() {
+  if (document.activeElement.className == "blocklyHtmlInput" && resizeFromKeyboard) {
+    // If it is an input element, the resize might be triggered by the
+    // onscreen keyboard, but we also need to make sure only the height changed
+    return true;
+  }
+
+  return false;
+}
+
 /**
  * Converts screen coordinates to workspace coordinates.
  * @param {Blockly.WorkspaceSvg} ws The workspace to find the coordinates on.

--- a/core/utils.js
+++ b/core/utils.js
@@ -604,8 +604,10 @@ Blockly.utils.resizeTracker = function(workspace) {
   debounceTimeout = setTimeout(function(){
     var injectionDiv = workspace.getInjectionDiv();
     resizeFromKeyboard = true;
-    initialWidth = injectionDiv.clientWidth;
-    lastHeight = injectionDiv.clientHeight;
+    if (injectionDiv) {
+      initialWidth = injectionDiv.clientWidth;
+      lastHeight = injectionDiv.clientHeight;
+    }
   }, 1000);
 
   var injectionDiv = workspace.getInjectionDiv();


### PR DESCRIPTION
this is the freshest one try this one https://arcade.makecode.com/app/56ea276e327b4140571532c6e0a42035c2e37f12-31bcb065cf

(affects https://github.com/microsoft/pxt-arcade/issues/2792 
https://github.com/microsoft/pxt-arcade/issues/2793
https://github.com/microsoft/pxt-arcade/issues/2794
also https://github.com/microsoft/pxt-arcade/issues/2434 probably i gotta test)

This fix is to check if the resize is from the on screen keyboard popping up, and if it is, not hiding WidgetDiv and DropDownDiv since they will automatically focus on the workspace after hiding.

I also got rid of the modal change from before. The new behavior is:
Clicking with a mouse: is always inline
Clicking with touch on desktop: is always inline, on screen keyboard shows
Clicking with touch on mobile: modal

New uploadtrg!
https://arcade.makecode.com/app/56ea276e327b4140571532c6e0a42035c2e37f12-31bcb065cf

AND Here's a project with a bunch of inputs to test with https://makecode.com/_fPcPbXfs3F2F