### PR TITLE
Only set if fieldRow exists

### DIFF
--- a/core/insertion_marker_manager.js
+++ b/core/insertion_marker_manager.js
@@ -284,7 +284,9 @@ Blockly.InsertionMarkerManager.prototype.createMarkerBlock_ = function(sourceBlo
         for (var j = 0; j < sourceInput.fieldRow.length; j++) {
           var sourceField = sourceInput.fieldRow[j];
           var resultField = resultInput.fieldRow[j];
-          resultField.setValue(sourceField.getValue());
+          if (resultField) {
+            resultField.setValue(sourceField.getValue());
+          }
         }
       }
     }


### PR DESCRIPTION
related to https://github.com/microsoft/pxt/pull/7845

If things get misaligned again don't try to set fieldRow if it might not exist.