### PR TITLE
Remove edit options from context menus when in debug mode

### DIFF
--- a/blocks/loops.js
+++ b/blocks/loops.js
@@ -259,13 +259,13 @@ Blockly.Constants.Loops.CUSTOM_CONTEXT_MENU_CREATE_VARIABLES_GET_MIXIN = {
    * @this {Blockly.Block}
    */
   customContextMenu: function(options) {
-    if (this.isInFlyout || this.inDebugWorkspace()) {
+    if (this.isInFlyout) {
       return;
     }
     var variable = this.getField('VAR').getVariable();
     var varName = variable.name;
     if (!this.isCollapsed() && varName != null) {
-      var option = {enabled: true};
+      var option = {enabled: !this.inDebugWorkspace()};
       option.text =
           Blockly.Msg['VARIABLES_SET_CREATE_GET'].replace('%1', varName);
       var xmlField = Blockly.Variables.generateVariableFieldDom(variable);

--- a/blocks/loops.js
+++ b/blocks/loops.js
@@ -259,7 +259,7 @@ Blockly.Constants.Loops.CUSTOM_CONTEXT_MENU_CREATE_VARIABLES_GET_MIXIN = {
    * @this {Blockly.Block}
    */
   customContextMenu: function(options) {
-    if (this.isInFlyout) {
+    if (this.isInFlyout || this.inDebugWorkspace()) {
       return;
     }
     var variable = this.getField('VAR').getVariable();

--- a/blocks/procedures.js
+++ b/blocks/procedures.js
@@ -390,7 +390,7 @@ Blockly.Blocks['procedures_defnoreturn'] = {
     options.push(option);
 
     // Add options to create getters for each parameter.
-    if (!this.isCollapsed()) {
+    if (!this.isCollapsed() && !this.inDebugWorkspace()) {
       for (var i = 0; i < this.argumentVarModels_.length; i++) {
         var argOption = {enabled: true};
         var argVar = this.argumentVarModels_[i];

--- a/blocks/procedures.js
+++ b/blocks/procedures.js
@@ -373,7 +373,7 @@ Blockly.Blocks['procedures_defnoreturn'] = {
       return;
     }
     // Add option to create caller.
-    var option = {enabled: true};
+    var option = {enabled: !this.options.debugMode};
     var name = this.getFieldValue('NAME');
     option.text = Blockly.Msg['PROCEDURES_CREATE_DO'].replace('%1', name);
     var xmlMutation = Blockly.utils.xml.createElement('mutation');
@@ -390,9 +390,9 @@ Blockly.Blocks['procedures_defnoreturn'] = {
     options.push(option);
 
     // Add options to create getters for each parameter.
-    if (!this.isCollapsed() && !this.inDebugWorkspace()) {
+    if (!this.isCollapsed()) {
       for (var i = 0; i < this.argumentVarModels_.length; i++) {
-        var argOption = {enabled: true};
+        var argOption = {enabled: !this.inDebugWorkspace()};
         var argVar = this.argumentVarModels_[i];
         argOption.text = Blockly.Msg['VARIABLES_SET_CREATE_GET']
             .replace('%1', argVar.name);

--- a/blocks/pxt_blockly_functions.js
+++ b/blocks/pxt_blockly_functions.js
@@ -1018,6 +1018,7 @@ Blockly.Blocks['function_definition'] = {
   },
 
   customContextMenu: function(menuOptions) {
+    if (this.inDebugWorkspace()) return;
     menuOptions.push(Blockly.Functions.makeEditOption(this));
     menuOptions.push(Blockly.Functions.makeCreateCallOption(this));
   },

--- a/blocks/variables.js
+++ b/blocks/variables.js
@@ -118,7 +118,7 @@ Blockly.Constants.Variables.CUSTOM_CONTEXT_MENU_VARIABLE_GETTER_SETTER_MIXIN = {
    * @this {Blockly.Block}
    */
   customContextMenu: function(options) {
-    if (this.isCollapsed()) {
+    if (this.isCollapsed() || this.inDebugWorkspace()) {
       return;
     }
 
@@ -182,7 +182,7 @@ Blockly.Constants.Variables.CUSTOM_CONTEXT_MENU_VARIABLE_REPORTER_MIXIN = {
    * @this Blockly.Block
    */
   customContextMenu: function(options) {
-    if (this.isCollapsed()) {
+    if (this.isCollapsed() || this.inDebugWorkspace()) {
       return;
     }
     var renameOption = {

--- a/blocks/variables.js
+++ b/blocks/variables.js
@@ -118,7 +118,7 @@ Blockly.Constants.Variables.CUSTOM_CONTEXT_MENU_VARIABLE_GETTER_SETTER_MIXIN = {
    * @this {Blockly.Block}
    */
   customContextMenu: function(options) {
-    if (this.isCollapsed() || this.inDebugWorkspace()) {
+    if (this.isCollapsed()) {
       return;
     }
 
@@ -133,7 +133,7 @@ Blockly.Constants.Variables.CUSTOM_CONTEXT_MENU_VARIABLE_GETTER_SETTER_MIXIN = {
         var contextMenuMsg = Blockly.Msg['VARIABLES_SET_CREATE_GET'];
       }
 
-      var option = {enabled: this.workspace.remainingCapacity() > 0};
+      var option = {enabled: this.workspace.remainingCapacity() > 0 && !this.inDebugWorkspace()};
       var name = this.getField('VAR').getText();
       option.text = contextMenuMsg.replace('%1', name);
       var xmlField = Blockly.utils.xml.createElement('field');
@@ -149,13 +149,13 @@ Blockly.Constants.Variables.CUSTOM_CONTEXT_MENU_VARIABLE_GETTER_SETTER_MIXIN = {
       if (this.type == 'variables_get' || this.type == 'variables_get_reporter') {
         var renameOption = {
           text: Blockly.Msg.RENAME_VARIABLE,
-          enabled: true,
+          enabled: !this.inDebugWorkspace(),
           callback: Blockly.Constants.Variables.RENAME_OPTION_CALLBACK_FACTORY(this)
         };
         var name = this.getField('VAR').getText();
         var deleteOption = {
           text: Blockly.Msg.DELETE_VARIABLE.replace('%1', name),
-          enabled: true,
+          enabled: !this.inDebugWorkspace(),
           callback: Blockly.Constants.Variables.DELETE_OPTION_CALLBACK_FACTORY(this)
         };
         options.unshift(renameOption);
@@ -182,12 +182,12 @@ Blockly.Constants.Variables.CUSTOM_CONTEXT_MENU_VARIABLE_REPORTER_MIXIN = {
    * @this Blockly.Block
    */
   customContextMenu: function(options) {
-    if (this.isCollapsed() || this.inDebugWorkspace()) {
+    if (this.isCollapsed()) {
       return;
     }
     var renameOption = {
       text: Blockly.Msg.RENAME_VARIABLE,
-      enabled: true,
+      enabled: !this.inDebugWorkspace(),
       callback: Blockly.Constants.Variables.RENAME_OPTION_CALLBACK_FACTORY(this)
     };
     options.unshift(renameOption);
@@ -198,7 +198,7 @@ Blockly.Constants.Variables.CUSTOM_CONTEXT_MENU_VARIABLE_REPORTER_MIXIN = {
         options.unshift(separator);
       }
       for (var i = variablesList.length - 1; i >= 0; i--) {
-        var option = {enabled: true};
+        var option = {enabled: !this.inDebugWorkspace()};
         option.text = variablesList[i].name;
 
         option.callback =

--- a/blocks/variables_dynamic.js
+++ b/blocks/variables_dynamic.js
@@ -95,6 +95,8 @@ Blockly.Constants.VariablesDynamic.CUSTOM_CONTEXT_MENU_VARIABLE_GETTER_SETTER_MI
    * @this {Blockly.Block}
    */
   customContextMenu: function(options) {
+    if (!this.inDebugWorkspace()) return;
+
     // Getter blocks have the option to create a setter block, and vice versa.
     if (!this.isInFlyout) {
       var opposite_type;
@@ -123,8 +125,9 @@ Blockly.Constants.VariablesDynamic.CUSTOM_CONTEXT_MENU_VARIABLE_GETTER_SETTER_MI
       option.callback = Blockly.ContextMenu.callbackFactory(this, xmlBlock);
       options.push(option);
     } else {
-      if (this.type == 'variables_get_dynamic' ||
-       this.type == 'variables_get_reporter_dynamic') {
+      if ((this.type == 'variables_get_dynamic' ||
+       this.type == 'variables_get_reporter_dynamic') &&
+       !this.inDebugWorkspace()) {
         var renameOption = {
           text: Blockly.Msg.RENAME_VARIABLE,
           enabled: true,

--- a/blocks/variables_dynamic.js
+++ b/blocks/variables_dynamic.js
@@ -126,17 +126,16 @@ Blockly.Constants.VariablesDynamic.CUSTOM_CONTEXT_MENU_VARIABLE_GETTER_SETTER_MI
       options.push(option);
     } else {
       if ((this.type == 'variables_get_dynamic' ||
-       this.type == 'variables_get_reporter_dynamic') &&
-       !this.inDebugWorkspace()) {
+       this.type == 'variables_get_reporter_dynamic')) {
         var renameOption = {
           text: Blockly.Msg.RENAME_VARIABLE,
-          enabled: true,
+          enabled: !this.inDebugWorkspace(),
           callback: Blockly.Constants.Variables.RENAME_OPTION_CALLBACK_FACTORY(this)
         };
         var name = this.getField('VAR').getText();
         var deleteOption = {
           text: Blockly.Msg.DELETE_VARIABLE.replace('%1', name),
-          enabled: true,
+          enabled: !this.inDebugWorkspace(),
           callback: Blockly.Constants.Variables.DELETE_OPTION_CALLBACK_FACTORY(this)
         };
         options.unshift(renameOption);

--- a/core/block.js
+++ b/core/block.js
@@ -775,7 +775,7 @@ Blockly.Block.prototype.getDescendants = function(ordered, opt_ignoreShadows) {
  */
 Blockly.Block.prototype.isDeletable = function() {
   return this.deletable_ && !this.isShadow_ &&
-      !(this.workspace && (this.workspace.options.readOnly || this.workspace.options.debugMode));
+      !(this.workspace && this.workspace.options.readOnly);
 };
 
 /**

--- a/core/block.js
+++ b/core/block.js
@@ -775,7 +775,15 @@ Blockly.Block.prototype.getDescendants = function(ordered, opt_ignoreShadows) {
  */
 Blockly.Block.prototype.isDeletable = function() {
   return this.deletable_ && !this.isShadow_ &&
-      !(this.workspace && this.workspace.options.readOnly);
+      !(this.workspace && (this.workspace.options.readOnly || this.workspace.options.debugMode));
+};
+
+/**
+ * Get whether this block is in a workspace with the debugMode option set or not.
+ * @return {boolean} True if deletable.
+ */
+ Blockly.Block.prototype.inDebugWorkspace = function() {
+  return !!(this.workspace && this.workspace.options.debugMode);
 };
 
 /**
@@ -791,7 +799,7 @@ Blockly.Block.prototype.setDeletable = function(deletable) {
  * @return {boolean} True if movable.
  */
 Blockly.Block.prototype.isMovable = function() {
-  return this.isMovablePersisted() && !(this.workspace && this.workspace.options.debugMode);
+  return this.isMovablePersisted() && !this.inDebugWorkspace();
 };
 
 /**
@@ -875,7 +883,7 @@ Blockly.Block.prototype.setInsertionMarker = function(insertionMarker) {
  * @return {boolean} True if editable.
  */
 Blockly.Block.prototype.isEditable = function() {
-  return this.isEditablePersisted() && !(this.workspace && this.workspace.options.debugMode);
+  return this.isEditablePersisted() && !this.inDebugWorkspace();
 };
 
 /**

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -791,7 +791,7 @@ Blockly.BlockSvg.prototype.generateContextMenu = function() {
   var isTopBlock = block.previousConnection == null && block.outputConnection == null;
 
   if (!this.isInFlyout) {
-    if (this.isDeletable() && this.isMovable() && !this.inDebugWorkspace()) {
+    if (this.isDeletable() && this.isMovable()) {
       menuOptions.push(Blockly.ContextMenu.blockDuplicateOption(block));
     }
 
@@ -810,7 +810,7 @@ Blockly.BlockSvg.prototype.generateContextMenu = function() {
                 this.inputList[i].type != Blockly.NEXT_STATEMENT) {
               // Only display this option if there are two value or dummy inputs
               // next to each other.
-              var inlineOption = {enabled: true};
+              var inlineOption = {enabled: !this.inDebugWorkspace()};
               var isInline = this.getInputsInline();
               inlineOption.text = isInline ?
                   Blockly.Msg['EXTERNAL_INPUTS'] : Blockly.Msg['INLINE_INPUTS'];
@@ -824,7 +824,7 @@ Blockly.BlockSvg.prototype.generateContextMenu = function() {
         }
         // Option to collapse block (pxt-blockly: top blocks only)
         if (this.workspace.options.collapse && isTopBlock) {
-          var collapseOption = {enabled: true};
+          var collapseOption = {enabled: !this.inDebugWorkspace()};
           collapseOption.text = Blockly.Msg['COLLAPSE_BLOCK'];
           collapseOption.callback = function() {
             block.setCollapsed(true);
@@ -834,7 +834,7 @@ Blockly.BlockSvg.prototype.generateContextMenu = function() {
       } else {
         // Option to expand block. (pxt-blockly: top blocks only)
         if (this.workspace.options.collapse && isTopBlock) {
-          var expandOption = {enabled: true};
+          var expandOption = {enabled: !this.inDebugWorkspace()};
           expandOption.text = Blockly.Msg['EXPAND_BLOCK'];
           expandOption.callback = function() {
             block.setCollapsed(false);
@@ -844,12 +844,12 @@ Blockly.BlockSvg.prototype.generateContextMenu = function() {
       }
     }
 
-    if (this.workspace.options.disable && this.isEditable() && !this.inDebugWorkspace()) {
+    if (this.workspace.options.disable && this.isEditable()) {
       // Option to disable/enable block.
       var disableOption = {
         text: this.isEnabled() ?
             Blockly.Msg['DISABLE_BLOCK'] : Blockly.Msg['ENABLE_BLOCK'],
-        enabled: !this.getInheritedDisabled(),
+        enabled: !this.getInheritedDisabled() && !this.inDebugWorkspace(),
         callback: function() {
           var group = Blockly.Events.getGroup();
           if (!group) {
@@ -864,7 +864,7 @@ Blockly.BlockSvg.prototype.generateContextMenu = function() {
       menuOptions.push(disableOption);
     }
 
-    if (this.isDeletable() && !this.inDebugWorkspace()) {
+    if (this.isDeletable()) {
       menuOptions.push(Blockly.ContextMenu.blockDeleteOption(block));
     }
   }

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -791,7 +791,7 @@ Blockly.BlockSvg.prototype.generateContextMenu = function() {
   var isTopBlock = block.previousConnection == null && block.outputConnection == null;
 
   if (!this.isInFlyout) {
-    if (this.isDeletable() && this.isMovable()) {
+    if (this.isDeletable() && this.isMovable() && !this.inDebugWorkspace()) {
       menuOptions.push(Blockly.ContextMenu.blockDuplicateOption(block));
     }
 
@@ -844,7 +844,7 @@ Blockly.BlockSvg.prototype.generateContextMenu = function() {
       }
     }
 
-    if (this.workspace.options.disable && this.isEditable()) {
+    if (this.workspace.options.disable && this.isEditable() && !this.inDebugWorkspace()) {
       // Option to disable/enable block.
       var disableOption = {
         text: this.isEnabled() ?
@@ -864,7 +864,7 @@ Blockly.BlockSvg.prototype.generateContextMenu = function() {
       menuOptions.push(disableOption);
     }
 
-    if (this.isDeletable()) {
+    if (this.isDeletable() && !this.inDebugWorkspace()) {
       menuOptions.push(Blockly.ContextMenu.blockDeleteOption(block));
     }
   }

--- a/core/contextmenu.js
+++ b/core/contextmenu.js
@@ -223,7 +223,7 @@ Blockly.ContextMenu.blockDeleteOption = function(block) {
   var deleteOption = {
     text: descendantCount == 1 ? Blockly.Msg['DELETE_BLOCK'] :
         Blockly.Msg['DELETE_X_BLOCKS'].replace('%1', String(descendantCount)),
-    enabled: true,
+    enabled: !block.inDebugWorkspace(),
     callback: function() {
       Blockly.Events.setGroup(true);
       block.dispose(true, true);
@@ -259,7 +259,7 @@ Blockly.ContextMenu.blockHelpOption = function(block) {
  * @package
  */
 Blockly.ContextMenu.blockDuplicateOption = function(block) {
-  var enabled = block.isDuplicatable();
+  var enabled = block.isDuplicatable() && !block.inDebugWorkspace();
   var duplicateOption = {
     text: Blockly.Msg['DUPLICATE_BLOCK'],
     enabled: enabled,
@@ -279,7 +279,7 @@ Blockly.ContextMenu.blockDuplicateOption = function(block) {
  */
 Blockly.ContextMenu.blockCommentOption = function(block) {
   var commentOption = {
-    enabled: !Blockly.utils.userAgent.IE
+    enabled: !Blockly.utils.userAgent.IE && !block.inDebugWorkspace()
   };
   // If there's already a comment, add an option to delete it.
   if (block.getCommentIcon()) {
@@ -308,7 +308,7 @@ Blockly.ContextMenu.blockCommentOption = function(block) {
 Blockly.ContextMenu.commentDeleteOption = function(comment) {
   var deleteOption = {
     text: Blockly.Msg['REMOVE_COMMENT'],
-    enabled: true,
+    enabled: !comment.workspace.options.debugMode,
     callback: function() {
       Blockly.Events.setGroup(true);
       comment.dispose(true, true);
@@ -328,7 +328,7 @@ Blockly.ContextMenu.commentDeleteOption = function(comment) {
 Blockly.ContextMenu.commentDuplicateOption = function(comment) {
   var duplicateOption = {
     text: Blockly.Msg['DUPLICATE_COMMENT'],
-    enabled: true,
+    enabled: !comment.workspace.options.debugMode,
     callback: function() {
       Blockly.duplicate(comment);
     }
@@ -393,7 +393,7 @@ Blockly.ContextMenu.workspaceCommentOption = function(ws, e) {
     // Foreign objects don't work in IE.  Don't let the user create comments
     // that they won't be able to edit.
     // TODO shakao check if uneditable comments still work
-    enabled: !Blockly.utils.userAgent.IE
+    enabled: !Blockly.utils.userAgent.IE && !ws.options.debugMode
   };
   wsCommentOption.text = Blockly.Msg['ADD_COMMENT'];
   wsCommentOption.callback = function() {

--- a/core/pxt_blockly_functions.js
+++ b/core/pxt_blockly_functions.js
@@ -384,7 +384,7 @@ Blockly.Functions.editFunctionExternalHandler = function(mutation, callback) {
  */
 Blockly.Functions.makeEditOption = function(block) {
   var editOption = {
-    enabled: true,
+    enabled: !block.inDebugWorkspace(),
     text: Blockly.Msg.FUNCTIONS_EDIT_OPTION,
     callback: function() {
       Blockly.Functions.editFunctionCallback_(block);
@@ -409,7 +409,7 @@ Blockly.Functions.makeCreateCallOption = function(block) {
   callBlock.setAttribute('type', 'function_call');
 
   var option = {
-    enabled: block.workspace.remainingCapacity() > 0,
+    enabled: block.workspace.remainingCapacity() > 0 && !block.inDebugWorkspace(),
     text: Blockly.Msg.FUNCTIONS_CREATE_CALL_OPTION.replace("%1", functionName),
     callback: Blockly.ContextMenu.callbackFactory(block, callBlock),
   };
@@ -418,7 +418,7 @@ Blockly.Functions.makeCreateCallOption = function(block) {
 
 Blockly.Functions.makeGoToDefinitionOption = function(block) {
   var gtdOption = {
-    enabled: true,
+    enabled: !block.inDebugWorkspace(),
     text: Blockly.Msg.FUNCTIONS_GO_TO_DEFINITION_OPTION,
     callback: function() {
       var functionName = block.getField("function_name").getText();

--- a/core/workspace_comment_svg.js
+++ b/core/workspace_comment_svg.js
@@ -198,7 +198,7 @@ Blockly.WorkspaceCommentSvg.prototype.showContextMenu = function(e) {
   var comment = this;
   var menuOptions = [];
 
-  if (this.isDeletable() && this.isMovable()) {
+  if (this.isDeletable() && this.isMovable() && !this.inDebugWorkspace()) {
     menuOptions.push(Blockly.ContextMenu.commentDuplicateOption(comment));
     menuOptions.push(Blockly.ContextMenu.commentDeleteOption(comment));
   }

--- a/core/workspace_comment_svg.js
+++ b/core/workspace_comment_svg.js
@@ -191,14 +191,14 @@ Blockly.WorkspaceCommentSvg.prototype.pathMouseDown_ = function(e) {
  * @package
  */
 Blockly.WorkspaceCommentSvg.prototype.showContextMenu = function(e) {
-  if (this.workspace.options.readOnly) {
+  if (this.workspace.options.readOnly || this.workspace.options.debugMode) {
     return;
   }
   // Save the current workspace comment in a variable for use in closures.
   var comment = this;
   var menuOptions = [];
 
-  if (this.isDeletable() && this.isMovable() && !this.inDebugWorkspace()) {
+  if (this.isDeletable() && this.isMovable()) {
     menuOptions.push(Blockly.ContextMenu.commentDuplicateOption(comment));
     menuOptions.push(Blockly.ContextMenu.commentDeleteOption(comment));
   }

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -1778,7 +1778,7 @@ Blockly.WorkspaceSvg.prototype.showContextMenu = function(e) {
     };
 
     // Option to collapse top blocks.
-    var collapseOption = {enabled: hasExpandedBlocks};
+    var collapseOption = {enabled: hasExpandedBlocks && !this.options.debugMode};
     collapseOption.text = Blockly.Msg['COLLAPSE_ALL'];
     collapseOption.callback = function() {
       toggleOption(true);
@@ -1786,7 +1786,7 @@ Blockly.WorkspaceSvg.prototype.showContextMenu = function(e) {
     menuOptions.push(collapseOption);
 
     // Option to expand top blocks.
-    var expandOption = {enabled: hasCollapsedBlocks};
+    var expandOption = {enabled: hasCollapsedBlocks && !this.options.debugMode};
     expandOption.text = Blockly.Msg['EXPAND_ALL'];
     expandOption.callback = function() {
       toggleOption(false);
@@ -1822,7 +1822,7 @@ Blockly.WorkspaceSvg.prototype.showContextMenu = function(e) {
   var deleteOption = {
     text: deleteList.length == 1 ? Blockly.Msg['DELETE_BLOCK'] :
         Blockly.Msg['DELETE_X_BLOCKS'].replace('%1', String(deleteList.length)),
-    enabled: deleteList.length > 0,
+    enabled: deleteList.length > 0 && !this.options.debugMode,
     callback: function() {
       if (ws.currentGesture_) {
         ws.currentGesture_.cancel();


### PR DESCRIPTION
Part of the fix for https://github.com/microsoft/pxt-arcade/issues/3220

Removes all options that could be used to edit the workspace when in debug mode. That includes:

1. Delete block(s)
2. Create get/set "var"
3. Edit function
4. Create call "function"
5. Rename variable
6. The list of variable names you get in some of the draggable variables in loops