### PR TITLE
Add unique random identifier to dropdown arrow SVG

### DIFF
--- a/core/field_dropdown.js
+++ b/core/field_dropdown.js
@@ -276,12 +276,13 @@ Blockly.FieldDropdown.prototype.createTextArrow_ = function() {
  * @protected
  */
 Blockly.FieldDropdown.prototype.createSVGArrow_ = function() {
-  
+
   // IE and iOS have issues with the <use> element, place the image inline instead
   // https://developer.mozilla.org/en-US/docs/Web/SVG/Element/use#Browser_compatibility
   var placeImageInline = Blockly.utils.userAgent.IE || Blockly.utils.userAgent.IOS;
   var arrowElement = placeImageInline ? 'image' : 'use';
-  var arrowHref = placeImageInline ? this.constants_.FIELD_DROPDOWN_SVG_ARROW_DATAURI : '#blocklyDropdownArrowSvg';
+  var arrowHref = placeImageInline ? this.constants_.FIELD_DROPDOWN_SVG_ARROW_DATAURI :
+    ("#" + (this.constants_.dropdownArrowImageId || 'blocklyDropdownArrowSvg'));
 
   this.svgArrow_ = Blockly.utils.dom.createSvgElement(arrowElement, {
     'height': this.constants_.FIELD_DROPDOWN_SVG_ARROW_SIZE + 'px',

--- a/core/renderers/pxt/constants.js
+++ b/core/renderers/pxt/constants.js
@@ -115,6 +115,13 @@ Blockly.pxt.ConstantProvider = function() {
    */
   this.warningGlowFilter_ = null;
 
+  /**
+   * The ID of the dropdown arrow SVG, or the empty string if no SVG is
+   * set.
+   * @type {string}
+   * @package
+   */
+  this.dropdownArrowImageId = ''
 };
 Blockly.utils.object.inherits(Blockly.pxt.ConstantProvider,
     Blockly.zelos.ConstantProvider);
@@ -209,12 +216,13 @@ Blockly.pxt.ConstantProvider.prototype.createDom = function(svg) {
   var arrowSize = this.FIELD_DROPDOWN_SVG_ARROW_SIZE;
   var dropdownArrowImage = Blockly.utils.dom.createSvgElement('image',
       {
-        'id': 'blocklyDropdownArrowSvg',
+        'id': 'blocklyDropdownArrowSvg' + this.randomIdentifier_,
         'height': arrowSize + 'px',
         'width': arrowSize + 'px'
       }, defs);
   dropdownArrowImage.setAttributeNS('http://www.w3.org/1999/xlink',
       'xlink:href', this.FIELD_DROPDOWN_SVG_ARROW_DATAURI);
+  this.dropdownArrowImageId = dropdownArrowImage.id;
 };
 
 /**


### PR DESCRIPTION
uses the same randomId method we use to uniquify the SVG filters on the dropdown arrow image as well

for https://github.com/microsoft/pxt-microbit/issues/3511