### PR TITLE
Use "list" default name

### DIFF
--- a/blocks/pxt_blockly_functions.js
+++ b/blocks/pxt_blockly_functions.js
@@ -466,8 +466,7 @@ Blockly.PXTBlockly.FunctionUtils.getShadowBlockInfoFromType_ = function(argument
     case 'Array':
       shadowType = 'variables_get';
       fieldName = "VAR";
-      fieldValue = Blockly.Variables.getOrCreateVariablePackage(ws, null,
-          Blockly.Msg.FUNCTIONS_DEFAULT_ARRAY_ARG_NAME, '').getId();
+      fieldValue = Blockly.Variables.getOrCreateVariablePackage(ws, null, "list", '').getId();
       break;
     default:
       // This is probably a custom type. Use a variable as the shadow.


### PR DESCRIPTION
Fix for https://github.com/microsoft/pxt-blockly/pull/348

Using Blockly.Msg.FUNCTIONS_DEFAULT_ARRAY_ARG_NAME didn't work -- it would just make an 'i' variable, so using "list" instead. I also tried out defining Arrays as part of "getArgumentDefaultName" using pxtarget in microbit, but then it doesn't play nicely with Array being a default type.

I can remove Arrays as defaults and make them defined target by target if that's preferred instead!