### PR TITLE
Array block fixes for datalogger

### DIFF
--- a/blocks/lists.js
+++ b/blocks/lists.js
@@ -265,16 +265,25 @@ Blockly.Blocks['lists_create_with'] = {
     this.restoreConnections_();
     // Add shadow block
     if (this.itemCount_ > 1) {
+
       // Find shadow type
       var firstInput = this.getInput('ADD' + 0);
       if (firstInput && firstInput.connection.targetConnection) {
         // Create a new shadow DOM with the same type as the first input
         // but with an empty default value
         var newInput = this.getInput('ADD' + (this.itemCount_ - 1));
-        var shadowInputDom = firstInput.connection.getShadowDom();
-        if (shadowInputDom) {
+        var connectedBlock = firstInput.connection.targetConnection;
+        var connectedBlockType = connectedBlock.getSourceBlock();
+
+        var newShadowType = connectedBlockType && connectedBlockType.type;
+        if (!newShadowType) {
+          var shadowInputDom = firstInput.connection.getShadowDom();
+          newShadowType = shadowInputDom && shadowInputDom.getAttribute('type');
+        }
+
+        if (newShadowType) {
           var shadowDom = Blockly.utils.xml.createElement('shadow');
-          var shadowInputType = shadowInputDom.getAttribute('type');
+          var shadowInputType = newShadowType;
           shadowDom.setAttribute('type', shadowInputType);
           var shadowDomField = Blockly.utils.xml.createElement('field');
           shadowDomField.setAttribute('name', 'NUM');

--- a/blocks/lists.js
+++ b/blocks/lists.js
@@ -280,9 +280,9 @@ Blockly.Blocks['lists_create_with'] = {
           for (var i = 0; i < childValues.length; i++) {
             var input = childValues[i];
             var inputName = input.getAttribute('name');
-            var fieldShadow = getChildrenByTag(input, 'shadow')[0];
-            var fieldShadowType = fieldShadow && fieldShadow.getAttribute('type');
-            appendValueDom(shadowDom, inputName, fieldShadowType);
+            var valueShadow = getChildrenByTag(input, 'shadow')[0];
+            var valueShadowType = valueShadow && valueShadow.getAttribute('type');
+            appendValueDom(shadowDom, inputName, valueShadowType);
           }
           newInput.connection.setShadowDom(shadowDom);
         }
@@ -299,9 +299,9 @@ Blockly.Blocks['lists_create_with'] = {
           if (connectedBlock && connectedBlock.inputList) {
             for (var i = 0; i < connectedBlock.inputList.length; i++) {
               var input = connectedBlock.inputList[i];
-              var fieldShadow = input.connection && input.connection.getShadowDom();
-              var fieldShadowType = fieldShadow && fieldShadow.getAttribute('type');
-              appendValueDom(blockDom, input.name, fieldShadowType);
+              var valueShadow = input.connection && input.connection.getShadowDom();
+              var valueShadowType = valueShadow && valueShadow.getAttribute('type');
+              appendValueDom(blockDom, input.name, valueShadowType);
             }
           }
           var fieldBlock = Blockly.Xml.domToBlock(blockDom, this.workspace);

--- a/blocks/lists.js
+++ b/blocks/lists.js
@@ -144,6 +144,7 @@ Blockly.Blocks['lists_create_with'] = {
     this.setHelpUrl(Blockly.Msg['LISTS_CREATE_WITH_HELPURL']);
     this.setStyle('list_blocks');
     this.itemCount_ = 3;
+    this.horizontalAfter_ = 3;
     this.updateShape_();
     this.setOutput(true, 'Array');
     this.setOutputShape(Blockly.OUTPUT_SHAPE_ROUND);
@@ -159,6 +160,9 @@ Blockly.Blocks['lists_create_with'] = {
   mutationToDom: function() {
     var container = Blockly.utils.xml.createElement('mutation');
     container.setAttribute('items', this.itemCount_);
+    if (this.horizontalAfter_) {
+      container.setAttribute('horizontalafter', this.horizontalAfter_);
+    }
     return container;
   },
   /**
@@ -168,6 +172,10 @@ Blockly.Blocks['lists_create_with'] = {
    */
   domToMutation: function(xmlElement) {
     this.itemCount_ = parseInt(xmlElement.getAttribute('items'), 10);
+    var horizontalAfterOverride = xmlElement.getAttribute('horizontalafter');
+    if (horizontalAfterOverride) {
+      this.horizontalAfter_ = parseInt(horizontalAfterOverride, 10);
+    }
     this.updateShape_();
   },
   /**
@@ -368,7 +376,7 @@ Blockly.Blocks['lists_create_with'] = {
     buttons.appendField(new Blockly.FieldImage(this.ADD_IMAGE_DATAURI, 24, 24, "*", add, false));
 
     /* Switch to vertical list when the list is too long */
-    var showHorizontalList = this.itemCount_ <= 5;
+    var showHorizontalList = this.itemCount_ <= this.horizontalAfter_;
     this.setInputsInline(showHorizontalList);
     this.setOutputShape(showHorizontalList ?
       Blockly.OUTPUT_SHAPE_ROUND : Blockly.OUTPUT_SHAPE_SQUARE);

--- a/blocks/lists.js
+++ b/blocks/lists.js
@@ -265,7 +265,6 @@ Blockly.Blocks['lists_create_with'] = {
     this.restoreConnections_();
     // Add shadow block
     if (this.itemCount_ > 1) {
-
       // Find shadow type
       var firstInput = this.getInput('ADD' + 0);
       if (firstInput && firstInput.connection.targetConnection) {
@@ -291,7 +290,7 @@ Blockly.Blocks['lists_create_with'] = {
         var targetConnection = firstInput.connection.targetConnection;
         var connectedBlock = targetConnection && targetConnection.getSourceBlock();
         var newFieldType = connectedBlock && connectedBlock.type;
-        if (newFieldType === newShadowType) {
+        if (!newFieldType || newFieldType === newShadowType) {
           // block in the slot matches shadow; respawn to emit shadow block
           newInput.connection.respawnShadow_();
         } else {

--- a/blocks/lists.js
+++ b/blocks/lists.js
@@ -272,17 +272,31 @@ Blockly.Blocks['lists_create_with'] = {
         // Create a new shadow DOM with the same type as the first input
         // but with an empty default value
         var newInput = this.getInput('ADD' + (this.itemCount_ - 1));
-        var connectedBlock = firstInput.connection.targetConnection;
-        var connectedBlockType = connectedBlock.getSourceBlock();
+        var targetConnection = firstInput.connection.targetConnection;
+        var connectedBlock = targetConnection && targetConnection.getSourceBlock();
+        var newShadowType = connectedBlock && connectedBlock.type;
 
-        var newShadowType = connectedBlockType && connectedBlockType.type;
         if (!newShadowType) {
           var shadowInputDom = firstInput.connection.getShadowDom();
           newShadowType = shadowInputDom && shadowInputDom.getAttribute('type');
         }
+        // TODO: make it so it is created as a field on top of the current shadow, not instead of?
 
         if (newShadowType) {
           var shadowDom = createShadowDom(newShadowType);
+          if (connectedBlock && connectedBlock.inputList) {
+            for (var i = 0; i < connectedBlock.inputList.length; i++) {
+              var input = connectedBlock.inputList[i];
+              var fieldShadow = input.connection && input.connection.getShadowDom();
+              var fieldShadowType = fieldShadow && fieldShadow.getAttribute('type');
+              if (!fieldShadowType)
+                continue;
+              var value = Blockly.utils.xml.createElement('value');
+              value.setAttribute('name', input.name);
+              value.appendChild(createShadowDom(fieldShadowType));
+              shadowDom.appendChild(value);
+            }
+          }
           newInput.connection.setShadowDom(shadowDom);
           newInput.connection.respawnShadow_();
         }

--- a/blocks/lists.js
+++ b/blocks/lists.js
@@ -282,19 +282,21 @@ Blockly.Blocks['lists_create_with'] = {
         }
 
         if (newShadowType) {
-          var shadowDom = Blockly.utils.xml.createElement('shadow');
-          var shadowInputType = newShadowType;
-          shadowDom.setAttribute('type', shadowInputType);
-          var shadowDomField = Blockly.utils.xml.createElement('field');
-          shadowDomField.setAttribute('name', 'NUM');
-          shadowDom.appendChild(shadowDomField);
-          if (shadowDom) {
-            shadowDom.setAttribute('id', Blockly.utils.genUid());
-            newInput.connection.setShadowDom(shadowDom);
-            newInput.connection.respawnShadow_();
-          }
+          var shadowDom = createShadowDom(newShadowType);
+          newInput.connection.setShadowDom(shadowDom);
+          newInput.connection.respawnShadow_();
         }
       }
+    }
+
+    function createShadowDom(type) {
+      var shadowDom = Blockly.utils.xml.createElement('shadow');
+      shadowDom.setAttribute('type', type);
+      var shadowDomField = Blockly.utils.xml.createElement('field');
+      shadowDomField.setAttribute('name', 'NUM');
+      shadowDom.appendChild(shadowDomField);
+      shadowDom.setAttribute('id', Blockly.utils.genUid());
+      return shadowDom;
     }
   },
   removeItem_: function() {

--- a/blocks/lists.js
+++ b/blocks/lists.js
@@ -336,9 +336,6 @@ Blockly.Blocks['lists_create_with'] = {
     function createBlockDom(tag, type) {
       var shadowDom = Blockly.utils.xml.createElement(tag);
       shadowDom.setAttribute('type', type);
-      var shadowDomField = Blockly.utils.xml.createElement('field');
-      shadowDomField.setAttribute('name', 'NUM');
-      shadowDom.appendChild(shadowDomField);
       shadowDom.setAttribute('id', Blockly.utils.genUid());
       return shadowDom;
     }


### PR DESCRIPTION
* Make arrays switch to vertical layout after 4+ slots have been added by default (vs. 6 before) https://github.com/microsoft/pxt-microbit/issues/4177
* Makes that configurable as fix for https://github.com/microsoft/pxt-microbit/issues/4177 (the builds below have `mut.setAttribute("horizontalafter", "" + itemCount);` set here: https://github.com/microsoft/pxt/blob/30a0beeea9e36a6bdb2fa5cd065380d036446d10/pxtblocks/blocklyloader.ts#L271 for example to make it so  non-strings / boolean shadows switch to vertical layout after 3+ instead). If we want it to always go to vertical for that block I'll just need to add a blockattribute for that I suppose
* Fill out nested shadow values one layer deep (shouldn't be any harder to make it recursive, but that feels a little unnecessary / I don't think it hits anything currently anyways?) -- fix for https://github.com/microsoft/pxt-microbit/issues/4161
* If the first slot in the array doesn't have a shadow or has a shadow that doesn't match the current value (e.g. it's a number and value is an array), attach a shallow clone of the visible block as a field -- fix for https://github.com/microsoft/pxt-arcade/issues/1779, but it's very easy to move to a separate pr if it needs discussion.

microbit build: https://makecode.microbit.org/app/2393d789a615db76bdf3d3d53e56acec72ba9685-5df27094a9
arcade build: https://arcade.makecode.com/app/4247fc12189539fbfc2a88a44535b149524b397f-91a6e67c53