### PR TITLE
fix selenium build in ci

### DIFF
--- a/tests/scripts/selenium-config.js
+++ b/tests/scripts/selenium-config.js
@@ -9,7 +9,7 @@ module.exports = {
     chrome: {
       // check for more recent versions of chrome driver here:
       // https://chromedriver.storage.googleapis.com/index.html
-      version: '89.0.4389.23',
+      version: '91.0.4472.101',
       arch: process.arch,
       baseURL: 'https://chromedriver.storage.googleapis.com'
     },


### PR DESCRIPTION
I guess we'll probably need to copy blockly's move over to github actions, but with this it's running again at least.

(the reason we need to make this change on occasion is that the chrome version changes underneath us; we can probably automate it by grabbing the final version based off the major/minor/patch here like: https://chromedriver.storage.googleapis.com/LATEST_RELEASE_92.0.4515) but easy enough to find when it breaks, just annoying.

![image](https://user-images.githubusercontent.com/5615930/122440384-5af15c80-cf51-11eb-864d-671d272f448c.png)

https://github.com/google/blockly/blob/master/.github/workflows/build.yml