### PR TITLE
Check connection before reconnecting function args

### DIFF
--- a/blocks/pxt_blockly_functions.js
+++ b/blocks/pxt_blockly_functions.js
@@ -616,7 +616,7 @@ Blockly.PXTBlockly.FunctionUtils.populateArgumentOnCaller_ = function(arg, conne
     oldShadow = saveInfo['shadow'];
   }
 
-  if (connectionMap && oldBlock) {
+  if (connectionMap && oldBlock && oldBlock.outputConnection.canConnectWithReason(input.connection) === Blockly.Connection.CAN_CONNECT) {
     // Reattach the old block and shadow DOM.
     connectionMap[input.name] = null;
     oldBlock.outputConnection.connect(input.connection);
@@ -624,6 +624,7 @@ Blockly.PXTBlockly.FunctionUtils.populateArgumentOnCaller_ = function(arg, conne
     input.connection.setShadowDom(shadowDom);
   } else {
     this.attachShadow_(input, arg.type);
+    if (oldBlock && oldBlock.isShadow_) oldBlock.setShadow(false);
   }
 };
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-arcade/issues/3623

If you recreate an argument input with the same name, verify that whatever was connected before *can* connect to the new input. If it can't, then we turn it into a full block if it's a shadow to prevent it from becoming a top-level shadow block.