### PR TITLE
bug fixed: missing "Create a function" button in flyout with "newFunctions" option

### DIFF
--- a/core/toolbox.js
+++ b/core/toolbox.js
@@ -185,7 +185,9 @@ Blockly.Toolbox.prototype.init = function() {
     oneBasedIndex: workspace.options.oneBasedIndex,
     horizontalLayout: workspace.horizontalLayout,
     toolboxPosition: workspace.options.toolboxPosition,
-    renderer: workspace.options.renderer
+    renderer: workspace.options.renderer,
+    // pxt-blockly: pass the newFunctions option
+    newFunctions: workspace.options.newFunctions
   });
   if (workspace.horizontalLayout) {
     if (!Blockly.HorizontalFlyout) {


### PR DESCRIPTION
testcase: Open tests/functions_playground.html, there is no "Create a function" button in "Functions" category flyout.
reason: The "newFunctions" option of flyout is not the same as toolbox option. Guillaume Jenkins <gujenkin@microsoft.com> set this option in Revision: 509553318b5c566468458951588ce2faa19913e3 Date: 2019/1/15 0:59:12, but it's crashed by mistake in a following commit. 