### PR TITLE
Add Github action for publshing to NPM

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -24,12 +24,6 @@ jobs:
     - name: Npm Install
       run: npm ci
 
-    - name: Configure Username
-      run: git config --global user.name "Microsoft MakeCode"
-
-    - name: Configure Email
-      run: git config --global user.email "kindscript@microsoft.com"
-
     - name: Linux Test Setup
       run: source ./tests/scripts/setup_linux_env.sh
 

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -40,7 +40,7 @@ jobs:
       run: npm run test
 
     - name: Npm Publish
-      run: npm publish --tag ${{ github.event.release.target_commitish }}
+      run: npm publish
 
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_ACCESS_TOKEN }}

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,0 +1,48 @@
+# This workflow will do a clean install, start the selenium server, run
+# tests, and publish the package files to Npm.
+
+name: PXT Npm Publish
+
+on:
+  push:
+    tags:
+    - '*'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: '14.x'
+        registry-url: https://registry.npmjs.org/
+
+    - name: Npm Install
+      run: npm ci
+
+    - name: Configure Username
+      run: git config --global user.name "Microsoft MakeCode"
+
+    - name: Configure Email
+      run: git config --global user.email "kindscript@microsoft.com"
+
+    - name: Linux Test Setup
+      run: source ./tests/scripts/setup_linux_env.sh
+
+    - name: Build
+      run: npm run build:core
+
+    - name: Run
+      run: npm run test
+
+    - name: Npm Publish
+      run: npm publish --tag ${{ github.event.release.target_commitish }}
+
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_ACCESS_TOKEN }}
+        DISPLAY: :99.0
+        CI: true

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -20,7 +20,6 @@ var appengineTasks = require('./scripts/gulpfiles/appengine_tasks');
 var releaseTasks = require('./scripts/gulpfiles/release_tasks');
 var cleanupTasks = require('./scripts/gulpfiles/cleanup_tasks');
 var pxtTasks = require('./scripts/gulpfiles/pxt_tasks');
-console.log("gulp file")
 
 module.exports = {
   deployDemos: appengineTasks.deployDemos,

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "license": "gulp checkLicenses",
     "lint": "eslint .",
     "package": "gulp package",
-    "prepare": "npm run package",
     "prepareDemos": "gulp prepareDemos",
     "publish": "gulp publish",
     "publish:beta": "gulp publishBeta",

--- a/scripts/gulpfiles/pxt_tasks.js
+++ b/scripts/gulpfiles/pxt_tasks.js
@@ -48,11 +48,15 @@ const pxtTest = gulp.series([buildTasks.core, pxtPublishTask]);
 // Task for bumping patch version and tagging commit. Travis will upload to npm.
 const pxtBump = gulp.series(
   // Sync to latest
-  execSync('git checkout develop', { stdio: 'inherit' }),
-  execSync('git pull origin develop', { stdio: 'inherit' }),
+  function(done) {
+    execSync('git checkout develop', { stdio: 'inherit' });
+    execSync('git pull origin develop', { stdio: 'inherit' });
+    done()
+  },
   // Build compressed files and typings
   buildTasks.core,
   typings.typings,
+  // Increment version and push tagged commit
   function (done) {
     var v = semver.inc(JSON.parse(fs.readFileSync('./package.json', 'utf8')).version, 'patch');
     gulp.src('./package.json')

--- a/scripts/gulpfiles/pxt_tasks.js
+++ b/scripts/gulpfiles/pxt_tasks.js
@@ -57,14 +57,14 @@ const pxtBump = gulp.series(
     var v = semver.inc(JSON.parse(fs.readFileSync('./package.json', 'utf8')).version, 'patch');
     gulp.src('./package.json')
       .pipe(gulp.bump({ "version": v }))
-      .pipe(gulp.dest('./'));
-
-    execSync('git add .', { stdio: 'inherit' });
-    execSync('git commit -m "' + v + '"', { stdio: 'inherit' });
-    execSync('git tag v' + v, { stdio: 'inherit' });
-    execSync('git push', { stdio: 'inherit' });
-    execSync('git push origin v' + v, { stdio: 'inherit' });
-    done();
+      .pipe(gulp.dest('./'))
+      .on('end', function () {
+        execSync('git add .', { stdio: 'inherit' });
+        execSync('git commit -m "' + v + '"', { stdio: 'inherit' });
+        execSync('git tag v' + v, { stdio: 'inherit' });
+        execSync('git push origin v' + v, { stdio: 'inherit' });
+        done();
+      });
   }
 )
 

--- a/scripts/gulpfiles/pxt_tasks.js
+++ b/scripts/gulpfiles/pxt_tasks.js
@@ -48,8 +48,8 @@ const pxtTest = gulp.series([buildTasks.core, pxtPublishTask]);
 // Task for bumping patch version and tagging commit. Travis will upload to npm.
 const pxtBump = gulp.series(
   // Sync to latest
-  // execSync('git checkout develop', { stdio: 'inherit' }),
-  // execSync('git pull origin develop', { stdio: 'inherit' }),
+  execSync('git checkout develop', { stdio: 'inherit' }),
+  execSync('git pull origin develop', { stdio: 'inherit' }),
   // Build compressed files and typings
   buildTasks.core,
   typings.typings,
@@ -59,7 +59,7 @@ const pxtBump = gulp.series(
       .pipe(gulp.bump({ "version": v }))
       .pipe(gulp.dest('./'))
       .on('end', function () {
-        execSync('git add .', { stdio: 'inherit' });
+        execSync('git add blockly_compressed.js blocks_compressed.js typings/blockly.d.ts package.json', { stdio: 'inherit' });
         execSync('git commit -m "' + v + '"', { stdio: 'inherit' });
         execSync('git tag v' + v, { stdio: 'inherit' });
         execSync('git push origin v' + v, { stdio: 'inherit' });

--- a/scripts/gulpfiles/pxt_tasks.js
+++ b/scripts/gulpfiles/pxt_tasks.js
@@ -62,7 +62,8 @@ const pxtBump = gulp.series(
     execSync('git add .', { stdio: 'inherit' });
     execSync('git commit -m "' + v + '"', { stdio: 'inherit' });
     execSync('git tag v' + v, { stdio: 'inherit' });
-    execSync('git push origin v' + v, { stdio: 'inherit' })
+    execSync('git push', { stdio: 'inherit' });
+    execSync('git push origin v' + v, { stdio: 'inherit' });
     done();
   }
 )


### PR DESCRIPTION
Fixes the pxt bump gulp taks (`num run pxt:bump`) and adds a github action which runs on tagged commits to publish to npm. I'll make a separate PR manually bumping to a clean version (accidentally published 4.0.1 while testing) then do a bump!