### PR TITLE
Bump version to 4.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pxt-blockly",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "Blockly fork for Microsoft MakeCode",
   "author": "Microsoft",
   "license": "MIT",


### PR DESCRIPTION
used this version for testing, manually bumping so that the github action can start from a clean one!