### PR TITLE
Remove unnecessary callValidator from slider field

### DIFF
--- a/core/field_colour_slider.js
+++ b/core/field_colour_slider.js
@@ -233,10 +233,6 @@ Blockly.FieldColourSlider.prototype.sliderCallbackFactory_ = function(channel) {
         break;
     }
     var colour = Blockly.utils.colour.hsvToHex(hsv[0], hsv[1], hsv[2]);
-    if (thisField.sourceBlock_) {
-      // Call any validation function, and allow it to override.
-      colour = thisField.callValidator(colour);
-    }
     if (colour !== null) {
       thisField.setValue(colour, true);
     }

--- a/core/field_slider.js
+++ b/core/field_slider.js
@@ -198,10 +198,6 @@ Blockly.FieldSlider.prototype.addSlider_ = function(contentDiv) {
       goog.ui.Component.EventType.CHANGE,
       function(event) {
         var val = event.target.getValue() || 0;
-        if (thisField.sourceBlock_) {
-          // Call any validation function, and allow it to override.
-          val = thisField.callValidator(val);
-        }
         if (val !== null) {
           thisField.setValue(val);
           var htmlInput = thisField.htmlInput_;


### PR DESCRIPTION
for https://github.com/microsoft/pxt-arcade/issues/4399 and https://github.com/microsoft/pxt-arcade/issues/4403

this function doesn't exist anymore and we don't need to call it, validation is done as part of the updated setValue flow