### PR TITLE
Fix exception when dropdown field is disposed on a non-svg block

### DIFF
--- a/core/field.js
+++ b/core/field.js
@@ -1050,7 +1050,8 @@ Blockly.Field.prototype.getTooltip = function() {
 Blockly.Field.prototype.getClickTarget_ = function() {
   if (this.clickTarget_) return this.clickTarget_;
 
-  if (!this.sourceBlock_) return null;
+  // pxt-blockly: make sure this is a blocksvg and not a regular block
+  if (!this.sourceBlock_ || !this.sourceBlock_.getSvgRoot) return null;
 
   var nFields = 0;
   var nConnections = 0;


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/4538