### PR TITLE
Prevent the insertion marker from creating variables

### DIFF
--- a/core/field_variable.js
+++ b/core/field_variable.js
@@ -128,7 +128,7 @@ Blockly.FieldVariable.prototype.configure_ = function(config) {
  * @package
  */
 Blockly.FieldVariable.prototype.initModel = function() {
-  if (this.variable_) {
+  if (this.variable_ || this.sourceBlock_ && this.sourceBlock_.isInsertionMarker()) {
     return;  // Initialization already happened.
   }
   var variable = Blockly.Variables.getOrCreateVariablePackage(


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/4678

The insertion marker is the little block that appears when you are dragging blocks around to show where they would go if you were to drop them. It works by making a clone of the block, and in this case that clone was trying to create a new variable.