### PR TITLE
Prevent hidden inputs from enabling connection tracking

### DIFF
--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -1586,6 +1586,7 @@ Blockly.BlockSvg.prototype.setConnectionTracking = function(track) {
   }
 
   for (var i = 0; i < this.inputList.length; i++) {
+    // pxtblockly: skip collapsed inputs (for expandable blocks)
     if (!this.inputList[i].isVisible()) continue;
     var conn = this.inputList[i].connection;
     if (conn) {

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -1586,6 +1586,7 @@ Blockly.BlockSvg.prototype.setConnectionTracking = function(track) {
   }
 
   for (var i = 0; i < this.inputList.length; i++) {
+    if (!this.inputList[i].isVisible()) continue;
     var conn = this.inputList[i].connection;
     if (conn) {
       conn.setTracking(track);

--- a/core/xml.js
+++ b/core/xml.js
@@ -592,6 +592,14 @@ Blockly.Xml.domToBlock = function(xmlBlock, workspace) {
       // blocks have rendered.
       setTimeout(function() {
         if (!topBlock.disposed) {
+          // pxtblockly: when expandable blocks are initialized, hidden inputs are collapsed. Check
+          // to see if this block is attached to a collapsed input before enabling connection tracking
+          if (topBlock.outputConnection && topBlock.outputConnection.targetConnection && topBlock.outputConnection.targetConnection.sourceBlock_) {
+            const connectedTo = topBlock.outputConnection.targetConnection.sourceBlock_;
+            const connectedInput = connectedTo.inputList.find(input => input.connection === topBlock.outputConnection.targetConnection);
+
+            if (!connectedInput.isVisible()) return;
+          }
           topBlock.setConnectionTracking(true);
         }
       }, 1);


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/4711

When blockly initializes a block in domToBlock, it does an async call to enable connection tracking on all of the child blocks. This messes with our expandable blocks that hide the inputs those blocks are connected to; the end result is a hidden block that you can still connect to.

This fix just checks for that scenario before setting the connection tracking.