### PR TITLE
Only use output shape for output connections

### DIFF
--- a/core/renderers/zelos/constants.js
+++ b/core/renderers/zelos/constants.js
@@ -652,7 +652,6 @@ Blockly.zelos.ConstantProvider.prototype.shapeFor = function(
     checks = connection.targetConnection.getCheck();
   }
   switch (connection.type) {
-    case Blockly.connectionTypes.INPUT_VALUE:
     case Blockly.connectionTypes.OUTPUT_VALUE:
       var outputShape = connection.getSourceBlock().getOutputShape();
       // If the block has an output shape set, use that instead.
@@ -663,6 +662,8 @@ Blockly.zelos.ConstantProvider.prototype.shapeFor = function(
           case this.SHAPES.SQUARE: return this.SQUARED;
         }
       }
+      // falls through
+    case Blockly.connectionTypes.INPUT_VALUE:
       // Includes doesn't work in IE.
       if (checks && checks.indexOf('Boolean') != -1) {
         return this.HEXAGONAL;


### PR DESCRIPTION
#### Problem
The shape of input connections should be decided based on the check type and not the output shape of the source block. This leads to blocks that return a Boolean having all inputs shaped as hexagons as well, even if the inputs are not Booleans themselves.

#### Solution
Only use the output shape of the source block for OUTPUT_VALUE connection types. Use the check type otherwise.

#### Validation
 Built and ran locally using pxt-microbit. The `game_sprite_touching_sprite` block now has circular connections for its sprite inputs vs the hexagonal ones it used to have.

Build: https://microbit.staging.pxt.io/app/d6f9b2143795af11f5046326f410a0f5a9dc4598-667bbfa881#editor

Fixes microsoft/pxt-microbit/issues/4130
