### PR TITLE
Check all parents for matching argument reporters instead of just root

### DIFF
--- a/core/connection_checker.js
+++ b/core/connection_checker.js
@@ -238,8 +238,16 @@ Blockly.ConnectionChecker.prototype.doDragChecks = function(a, b, distance) {
       if (Blockly.pxtBlocklyUtils.isFunctionArgumentReporter(a.getSourceBlock())) {
         // Ensure the root block of this stack has an argument reporter
         // matching the name and the type of this reporter.
-        var rootBlock = b.getSourceBlock().getRootBlock();
-        if (rootBlock.isEnabled() && !Blockly.pxtBlocklyUtils.hasMatchingArgumentReporter(rootBlock, a.getSourceBlock())) {
+        var parent = b.getSourceBlock().getParent();
+        var foundMatchingParent = false;
+        while (parent) {
+          if (!parent.isEnabled() || Blockly.pxtBlocklyUtils.hasMatchingArgumentReporter(parent, a.getSourceBlock())) {
+            foundMatchingParent = true;
+            break;
+          }
+          parent = parent.getParent();
+        }
+        if (!foundMatchingParent) {
           return false;
         }
       }


### PR DESCRIPTION
This is a fix for the menu extension, but is a longstanding issue i've run into multiple times in other extensions.

![image](https://user-images.githubusercontent.com/13754588/174192111-65abebdf-a806-45f7-bf36-34c2516d6bbb.png)


When checking if an argument reporter can be connected to an input, we previously just checked the root of the block to see if it had a matching argument defined. That meant only checking the top-level block and thus dockable blocks with statement inputs (like the one above) could not use argument reporters.

This fixes that check to check all the parents in the tree instead of just the root.