### PR TITLE
dont give a spurious console error whenever toolbox search is clicked

### DIFF
--- a/core/toolbox/toolbox.js
+++ b/core/toolbox/toolbox.js
@@ -307,7 +307,7 @@ Blockly.Toolbox.prototype.onClick_ = function(e) {
     var itemId = targetElement.getAttribute('id');
     if (itemId) {
       var item = this.getToolboxItemById(itemId);
-      if (item.isSelectable()) {
+      if (item && item.isSelectable()) {
         this.setSelectedItem(item);
         item.onClick(e);
       }


### PR DESCRIPTION
re: https://github.com/microsoft/pxt-minecraft/issues/2209, this one's just a spurious error that gets sent out / we don't actually use this path ourselves. It looks like the error prevents another event from running / setting up things properly? I haven't investigated too deeply as this 'works' and I'm not sure it's worth going down a potential rabbit hole right now

The toolbox search breaking occurs when you click on the toolbox search before opening any toolbox categories in the given session, and persists after that until you refresh the page.

build https://minecraft.makecode.com/app/4b711798559c11aebadb7559bcf7c31281e9767f-060ec125d7#editor

Worth a note, I have not successfully caused the error to occur on localhost, so it likely is just something like 'first click tries to initialize api cache for search toolbox and then fails indefinitely' or something that is disabled locally? not certain.

(and for reference the same build as above minus this change, since it's a bit hard to compare / I didn't narrow down the exact place it was breaking https://minecraft.makecode.com/app/cecbc006ccd4f73834468b81b2e70e379f227fca-7b47927910 -- after having ran the local pxt-blockly build to produce the first link I just swapped back to normal in pxt with `npm i` -> `gulp` and ran uploadtrg again)